### PR TITLE
refactor: utilsディレクトリをtoolsに変更、scriptsをtestsに統合

### DIFF
--- a/mmd_tools/tools/pmx_dumper.py
+++ b/mmd_tools/tools/pmx_dumper.py
@@ -1,0 +1,429 @@
+"""
+PMXファイルの構造を人間とLLMが読みやすい独自テキスト形式でダンプするツール
+"""
+
+import argparse
+import sys
+from typing import List, Optional, TextIO
+
+from mmd_tools.core import utils
+from mmd_tools.core.logger import get_logger
+from mmd_tools.core.pmx_data.bone import PmxBone
+from mmd_tools.core.pmx_data.material import PmxMaterial
+from mmd_tools.core.pmx_data.morph import PmxMorph
+from mmd_tools.core.pmx_data.vertex import PmxVertex
+from mmd_tools.core.pmx_parser import PmxParser
+
+logger = get_logger(__name__)
+
+
+class PmxDumper:
+    """PMXファイルの内容を人間が読みやすい形式でダンプするクラス"""
+
+    def __init__(self, pmx_data: PmxParser):
+        """
+        Args:
+            pmx_data: 解析済みのPMXデータ
+        """
+        self.pmx = pmx_data
+
+    def dump(
+        self,
+        output: Optional[TextIO] = None,
+        sections: Optional[List[str]] = None,
+        verbose: bool = False,
+    ) -> str:
+        """
+        PMXデータをダンプする
+
+        Args:
+            output: 出力先（None の場合は文字列として返す）
+            sections: 出力するセクションのリスト（None の場合は全セクション）
+            verbose: 詳細出力モード
+
+        Returns:
+            ダンプ結果の文字列（output が指定されている場合は空文字列）
+        """
+        buffer = []
+        
+        # 利用可能なセクション
+        available_sections = {
+            "header": self._dump_header,
+            "statistics": self._dump_statistics,
+            "bones": self._dump_bones,
+            "morphs": self._dump_morphs,
+            "materials": self._dump_materials,
+            "physics": self._dump_physics,
+            "vertices": self._dump_vertices,
+        }
+        
+        # セクションが指定されていない場合はデフォルトセット
+        if sections is None:
+            sections = ["header", "statistics", "bones", "morphs", "materials", "physics"]
+            if verbose:
+                sections.append("vertices")
+        
+        # 各セクションを出力
+        for section in sections:
+            if section in available_sections:
+                try:
+                    content = available_sections[section](verbose)
+                    buffer.append(content)
+                except Exception as e:
+                    buffer.append(f"\n=== {section.upper()} [ERROR] ===")
+                    buffer.append(f"Failed to dump section: {e}")
+        
+        result = "\n".join(buffer)
+        
+        if output:
+            output.write(result)
+            return ""
+        else:
+            return result
+
+    def _dump_header(self, verbose: bool = False) -> str:
+        """ヘッダー情報をダンプ"""
+        header = self.pmx.header
+        encoding = utils.get_pmx_encoding_string(header.encoding)
+        
+        lines = [
+            "=== PMX MODEL DEBUG DUMP ===",
+            f"Version: {header.version} | Encoding: {encoding}",
+            f"Model: {header.model_name} ({header.model_name_english})",
+            f"Comment: {header.comment[:50]}... " if len(header.comment) > 50 else f"Comment: {header.comment}",
+        ]
+        
+        if verbose:
+            lines.extend([
+                f"\nIndex Sizes:",
+                f"  Vertex: {header.vertex_index_size} bytes",
+                f"  Texture: {header.texture_index_size} bytes",
+                f"  Material: {header.material_index_size} bytes",
+                f"  Bone: {header.bone_index_size} bytes",
+                f"  Morph: {header.morph_index_size} bytes",
+                f"  Rigid Body: {header.rigid_body_index_size} bytes",
+                f"Additional UV: {header.additional_uv}",
+            ])
+        
+        return "\n".join(lines)
+
+    def _dump_statistics(self, verbose: bool = False) -> str:
+        """統計情報をダンプ"""
+        lines = [
+            "\n=== STATISTICS ===",
+            f"Vertices: {len(self.pmx.vertices):,} | Faces: {len(self.pmx.faces):,} | Materials: {len(self.pmx.materials)}",
+            f"Bones: {len(self.pmx.bones)} | Morphs: {len(self.pmx.morphs)} | Display Frames: {len(self.pmx.display_frames)}",
+            f"Rigid Bodies: {len(self.pmx.rigid_bodies)} | Joints: {len(self.pmx.joints)}",
+        ]
+        
+        if verbose and self.pmx.vertices:
+            # 頂点のウェイトタイプ別集計
+            weight_types = {}
+            for v in self.pmx.vertices:
+                weight_type = v.weight_transform_type
+                weight_types[weight_type] = weight_types.get(weight_type, 0) + 1
+            
+            lines.append("\nVertex Weight Types:")
+            for wtype, count in sorted(weight_types.items()):
+                wtype_name = {0: "BDEF1", 1: "BDEF2", 2: "BDEF4", 3: "SDEF", 4: "QDEF"}.get(wtype, f"Unknown({wtype})")
+                lines.append(f"  {wtype_name}: {count:,}")
+        
+        return "\n".join(lines)
+
+    def _dump_bones(self, verbose: bool = False) -> str:
+        """ボーン情報をダンプ"""
+        if not self.pmx.bones:
+            return "\n=== BONES (0) ===\nNo bones found."
+        
+        lines = [f"\n=== BONE HIERARCHY ({len(self.pmx.bones)}) ==="]
+        
+        # ボーン階層を構築
+        root_bones = []
+        bone_children = {}
+        
+        for i, bone in enumerate(self.pmx.bones):
+            if bone.parent_bone_index == -1:
+                root_bones.append(i)
+            else:
+                if bone.parent_bone_index not in bone_children:
+                    bone_children[bone.parent_bone_index] = []
+                bone_children[bone.parent_bone_index].append(i)
+        
+        # 階層を表示（最大10個まで）
+        def dump_bone_tree(index: int, indent: str = "", is_last: bool = True, depth: int = 0) -> List[str]:
+            if depth > 3:  # 深さ制限
+                return []
+            
+            bone = self.pmx.bones[index]
+            tree_lines = []
+            
+            # フラグを解析
+            flags = []
+            if bone.bone_flag & 0x0020:  # IK
+                flags.append("IK")
+            if bone.bone_flag & 0x0002:  # 回転可能
+                flags.append("ROT")
+            if bone.bone_flag & 0x0004:  # 移動可能
+                flags.append("MOVE")
+            if bone.bone_flag & 0x0008:  # 表示
+                flags.append("VIS")
+            if bone.bone_flag & 0x0010:  # 操作可能
+                flags.append("EN")
+            
+            flag_str = f" [{'+'.join(flags)}]" if flags else ""
+            
+            # 接続先情報を取得
+            if bone.bone_flag & 0x0001:  # 接続先がボーン
+                tail_str = f" → [{bone.connect_bone_index}]" if bone.connect_bone_index >= 0 else ""
+            else:  # 接続先が相対座標
+                tail_str = f" → offset({bone.connect_position_offset[0]:.1f}, {bone.connect_position_offset[1]:.1f}, {bone.connect_position_offset[2]:.1f})"
+            
+            prefix = "└─" if is_last else "├─"
+            tree_lines.append(f"{indent}{prefix}[{index}] {bone.name} ({bone.name_english}){flag_str}{tail_str}")
+            
+            # 子ボーンを表示
+            if index in bone_children:
+                children = bone_children[index][:5]  # 最大5個の子
+                for i, child_idx in enumerate(children):
+                    is_last_child = i == len(children) - 1
+                    child_indent = indent + ("    " if is_last else "│   ")
+                    tree_lines.extend(dump_bone_tree(child_idx, child_indent, is_last_child, depth + 1))
+                
+                if len(bone_children[index]) > 5:
+                    tree_lines.append(f"{indent}{'    ' if is_last else '│   '}... and {len(bone_children[index]) - 5} more")
+            
+            return tree_lines
+        
+        # ルートボーンから表示
+        for i, root_idx in enumerate(root_bones[:5]):  # 最大5個のルート
+            is_last = i == len(root_bones) - 1 or i == 4
+            lines.extend(dump_bone_tree(root_idx, "", is_last))
+        
+        if len(root_bones) > 5:
+            lines.append(f"... and {len(root_bones) - 5} more root bones")
+        
+        # IKボーンの詳細（verbose時）
+        if verbose:
+            lines.append("\n=== BONE DETAILS ===")
+            ik_bones = [b for b in self.pmx.bones if b.bone_flag & 0x0020][:5]  # IKフラグが立っているボーン、最大5個
+            
+            for bone in ik_bones:
+                lines.append(f"\n[{self.pmx.bones.index(bone)}] {bone.name} ({bone.name_english})")
+                parent_name = self.pmx.bones[bone.parent_bone_index].name if bone.parent_bone_index >= 0 else "None"
+                lines.append(f"    Parent: [{bone.parent_bone_index}] {parent_name} | Layer: {bone.transform_layer}")
+                lines.append(f"    Position: ({bone.position[0]:.3f}, {bone.position[1]:.3f}, {bone.position[2]:.3f})")
+                lines.append(f"    Flags: 0x{bone.bone_flag:04X}")
+                
+                if bone.bone_flag & 0x0020:  # IKフラグが立っている場合
+                    lines.append(f"    IK Target: [{bone.ik_target_bone_index}] | Loop: {bone.ik_loop_count} | Limit: {bone.ik_limit_angle:.2f} rad")
+                    if bone.ik_links:
+                        lines.append(f"    IK Links: {len(bone.ik_links)} links")
+                        for link in bone.ik_links[:3]:  # 最大3個
+                            limit_str = ""
+                            if hasattr(link, 'angle_limit') and link.angle_limit:
+                                limit_str = f" [角度制限] ({link.lower_limit[0]:.2f}~{link.upper_limit[0]:.2f}, {link.lower_limit[1]:.2f}~{link.upper_limit[1]:.2f}, {link.lower_limit[2]:.2f}~{link.upper_limit[2]:.2f})"
+                            lines.append(f"        [{link.bone_index}]{limit_str}")
+        
+        return "\n".join(lines)
+
+    def _dump_morphs(self, verbose: bool = False) -> str:
+        """モーフ情報をダンプ"""
+        if not self.pmx.morphs:
+            return "\n=== MORPHS (0) ===\nNo morphs found."
+        
+        lines = [f"\n=== MORPHS ({len(self.pmx.morphs)}) ==="]
+        
+        # モーフタイプ別に集計
+        morph_types = {}
+        for morph in self.pmx.morphs:
+            morph_type = morph.morph_type
+            morph_types[morph_type] = morph_types.get(morph_type, 0) + 1
+        
+        lines.append("Morph Types:")
+        type_names = {
+            0: "Group", 1: "Vertex", 2: "Bone", 3: "UV",
+            4: "UV2", 5: "UV3", 6: "UV4", 7: "UV5",
+            8: "Material", 9: "Flip", 10: "Impulse"
+        }
+        for mtype, count in sorted(morph_types.items()):
+            type_name = type_names.get(mtype, f"Unknown({mtype})")
+            lines.append(f"  {type_name}: {count}")
+        
+        # 主要なモーフをリスト（最大10個）
+        lines.append("\nMorph List:")
+        for i, morph in enumerate(self.pmx.morphs[:10]):
+            panel = {1: "眉", 2: "目", 3: "口", 4: "他"}.get(morph.panel, "?")
+            type_name = type_names.get(morph.morph_type, "?")
+            lines.append(f"  [{i}] {morph.name} ({morph.name_english}) - {type_name} [Panel: {panel}]")
+        
+        if len(self.pmx.morphs) > 10:
+            lines.append(f"  ... and {len(self.pmx.morphs) - 10} more morphs")
+        
+        return "\n".join(lines)
+
+    def _dump_materials(self, verbose: bool = False) -> str:
+        """材質情報をダンプ"""
+        if not self.pmx.materials:
+            return "\n=== MATERIALS (0) ===\nNo materials found."
+        
+        lines = [f"\n=== MATERIALS ({len(self.pmx.materials)}) ==="]
+        
+        for i, mat in enumerate(self.pmx.materials[:10]):  # 最大10個
+            lines.append(f"\n[{i}] {mat.name} ({mat.name_english})")
+            lines.append(f"    Diffuse: ({mat.diffuse[0]:.2f}, {mat.diffuse[1]:.2f}, {mat.diffuse[2]:.2f}, {mat.diffuse[3]:.2f})")
+            lines.append(f"    Specular: ({mat.specular[0]:.2f}, {mat.specular[1]:.2f}, {mat.specular[2]:.2f}) Power: {mat.specular_coefficient}")
+            lines.append(f"    Ambient: ({mat.ambient[0]:.2f}, {mat.ambient[1]:.2f}, {mat.ambient[2]:.2f})")
+            
+            # フラグ
+            flags = []
+            if mat.draw_flag & 0x01:  # 両面描画
+                flags.append("DoubleSide")
+            if mat.draw_flag & 0x02:  # 地面影
+                flags.append("Shadow")
+            if mat.draw_flag & 0x08:  # セルフシャドウ
+                flags.append("SelfShadow")
+            if mat.draw_flag & 0x10:  # エッジ描画
+                flags.append("Edge")
+            
+            lines.append(f"    Flags: {' | '.join(flags) if flags else 'None'}")
+            
+            # テクスチャ
+            if mat.texture_index >= 0:
+                tex_path = self.pmx.textures[mat.texture_index] if mat.texture_index < len(self.pmx.textures) else "[Invalid]"
+                lines.append(f"    Texture: [{mat.texture_index}] {tex_path}")
+            
+            lines.append(f"    Face Count: {mat.face_count // 3:,}")
+        
+        if len(self.pmx.materials) > 10:
+            lines.append(f"\n... and {len(self.pmx.materials) - 10} more materials")
+        
+        return "\n".join(lines)
+
+    def _dump_physics(self, verbose: bool = False) -> str:
+        """物理演算情報をダンプ"""
+        lines = ["\n=== PHYSICS ==="]
+        
+        if self.pmx.rigid_bodies:
+            lines.append(f"Rigid Bodies: {len(self.pmx.rigid_bodies)}")
+            
+            # 形状タイプ別集計
+            shape_types = {}
+            for rb in self.pmx.rigid_bodies:
+                shape = rb.shape_type
+                shape_types[shape] = shape_types.get(shape, 0) + 1
+            
+            lines.append("  Shape Types:")
+            shape_names = {0: "Sphere", 1: "Box", 2: "Capsule"}
+            for stype, count in sorted(shape_types.items()):
+                shape_name = shape_names.get(stype, f"Unknown({stype})")
+                lines.append(f"    {shape_name}: {count}")
+            
+            if verbose:
+                # 物理タイプ別集計
+                physics_modes = {}
+                for rb in self.pmx.rigid_bodies:
+                    mode = rb.physics_mode
+                    physics_modes[mode] = physics_modes.get(mode, 0) + 1
+                
+                lines.append("  Physics Modes:")
+                mode_names = {0: "Static", 1: "Dynamic", 2: "Dynamic + Bone"}
+                for mode, count in sorted(physics_modes.items()):
+                    mode_name = mode_names.get(mode, f"Unknown({mode})")
+                    lines.append(f"    {mode_name}: {count}")
+        else:
+            lines.append("Rigid Bodies: 0")
+        
+        if self.pmx.joints:
+            lines.append(f"\nJoints: {len(self.pmx.joints)}")
+            
+            if verbose and self.pmx.joints:
+                # ジョイントサンプル（最大3個）
+                lines.append("  Joint Samples:")
+                for i, joint in enumerate(self.pmx.joints[:3]):
+                    lines.append(f"    [{i}] {joint.name} ({joint.name_english})")
+                    lines.append(f"        Rigid Bodies: [{joint.rigid_body_a_index}] <-> [{joint.rigid_body_b_index}]")
+        else:
+            lines.append("Joints: 0")
+        
+        return "\n".join(lines)
+
+    def _dump_vertices(self, verbose: bool = False) -> str:
+        """頂点情報をダンプ（verboseモードのみ）"""
+        if not self.pmx.vertices:
+            return "\n=== VERTICES (0) ===\nNo vertices found."
+        
+        lines = [f"\n=== VERTICES ({len(self.pmx.vertices):,}) ==="]
+        
+        # 座標範囲を計算
+        min_pos = [float('inf')] * 3
+        max_pos = [float('-inf')] * 3
+        
+        for v in self.pmx.vertices:
+            for i in range(3):
+                min_pos[i] = min(min_pos[i], v.position[i])
+                max_pos[i] = max(max_pos[i], v.position[i])
+        
+        lines.append(f"Position Range:")
+        lines.append(f"  X: {min_pos[0]:.3f} ~ {max_pos[0]:.3f} (width: {max_pos[0] - min_pos[0]:.3f})")
+        lines.append(f"  Y: {min_pos[1]:.3f} ~ {max_pos[1]:.3f} (height: {max_pos[1] - min_pos[1]:.3f})")
+        lines.append(f"  Z: {min_pos[2]:.3f} ~ {max_pos[2]:.3f} (depth: {max_pos[2] - min_pos[2]:.3f})")
+        
+        # サンプル頂点（最大5個）
+        lines.append("\nVertex Samples:")
+        for i, v in enumerate(self.pmx.vertices[:5]):
+            deform_type = {0: "BDEF1", 1: "BDEF2", 2: "BDEF4", 3: "SDEF", 4: "QDEF"}.get(v.weight_transform_type, "?")
+            lines.append(f"  [{i}] Pos: ({v.position[0]:.3f}, {v.position[1]:.3f}, {v.position[2]:.3f}) | Normal: ({v.normal[0]:.2f}, {v.normal[1]:.2f}, {v.normal[2]:.2f}) | UV: ({v.uv[0]:.3f}, {v.uv[1]:.3f}) | Deform: {deform_type}")
+        
+        if len(self.pmx.vertices) > 5:
+            lines.append(f"  ... and {len(self.pmx.vertices) - 5:,} more vertices")
+        
+        return "\n".join(lines)
+
+
+def main():
+    """CLIエントリーポイント"""
+    parser = argparse.ArgumentParser(
+        description="PMXファイルの構造を人間が読みやすい形式でダンプします"
+    )
+    parser.add_argument("pmx_file", help="ダンプするPMXファイルのパス")
+    parser.add_argument(
+        "-o", "--output",
+        help="出力ファイルパス（指定しない場合は標準出力）"
+    )
+    parser.add_argument(
+        "-s", "--sections",
+        nargs="+",
+        choices=["header", "statistics", "bones", "morphs", "materials", "physics", "vertices"],
+        help="出力するセクションを指定（デフォルト: header statistics bones morphs materials physics）"
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="詳細情報を出力"
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        # PMXファイルを解析
+        pmx_parser = PmxParser()
+        pmx_parser.parse_file(args.pmx_file)
+        
+        # ダンパーを作成
+        dumper = PmxDumper(pmx_parser)
+        
+        # 出力先を決定
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as f:
+                dumper.dump(f, sections=args.sections, verbose=args.verbose)
+            print(f"Dump completed: {args.output}")
+        else:
+            print(dumper.dump(sections=args.sections, verbose=args.verbose))
+    
+    except Exception as e:
+        logger.error(f"Failed to dump PMX file: {e}", exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dump_pmx.py
+++ b/tests/dump_pmx.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""
+PMXファイルダンパーのCLIスクリプト
+
+使用例:
+    # 基本的な使用
+    mayapy tests/dump_pmx.py model.pmx
+    
+    # 出力ファイルを指定
+    mayapy tests/dump_pmx.py model.pmx -o dump.txt
+    
+    # セクションを指定
+    mayapy tests/dump_pmx.py model.pmx -s header statistics bones
+    
+    # 詳細モード
+    mayapy tests/dump_pmx.py model.pmx -v
+"""
+
+import os
+import sys
+
+# プロジェクトのルートディレクトリをパスに追加
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from mmd_tools.tools.pmx_dumper import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_pmx_dumper.py
+++ b/tests/unit/test_pmx_dumper.py
@@ -1,0 +1,166 @@
+"""
+PMXダンパーのユニットテスト
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from io import StringIO
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from mmd_tools.core.pmx_parser import PmxParser
+from mmd_tools.tools.pmx_dumper import PmxDumper
+from tests.common.pmx_mock import PmxMock
+
+
+class TestPmxDumper(unittest.TestCase):
+    """PMXダンパーのテストクラス"""
+
+    def setUp(self):
+        """テストの前処理"""
+        # モックPMXファイルを作成
+        pmx_data = PmxMock.create_minimal_pmx()
+        
+        # 一時ファイルに書き込み
+        with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.pmx') as f:
+            f.write(pmx_data)
+            self.test_pmx_path = f.name
+        
+        # PMXファイルを読み込む
+        self.pmx_parser = PmxParser()
+        self.pmx_parser.parse_file(self.test_pmx_path)
+        self.dumper = PmxDumper(self.pmx_parser)
+    
+    def tearDown(self):
+        """テストの後処理"""
+        # 一時ファイルを削除
+        if hasattr(self, 'test_pmx_path') and os.path.exists(self.test_pmx_path):
+            os.unlink(self.test_pmx_path)
+
+    def test_dump_header(self):
+        """ヘッダー情報のダンプテスト"""
+        result = self.dumper.dump(sections=["header"])
+        
+        # 基本的な内容を確認
+        self.assertIn("=== PMX MODEL DEBUG DUMP ===", result)
+        self.assertIn("Version:", result)
+        self.assertIn("Encoding:", result)
+        self.assertIn("Model:", result)
+        self.assertIn("Comment:", result)
+
+    def test_dump_statistics(self):
+        """統計情報のダンプテスト"""
+        result = self.dumper.dump(sections=["statistics"])
+        
+        # 統計情報の確認
+        self.assertIn("=== STATISTICS ===", result)
+        self.assertIn("Vertices:", result)
+        self.assertIn("Faces:", result)
+        self.assertIn("Materials:", result)
+        self.assertIn("Bones:", result)
+        self.assertIn("Morphs:", result)
+
+    def test_dump_bones(self):
+        """ボーン情報のダンプテスト"""
+        result = self.dumper.dump(sections=["bones"])
+        
+        # ボーン階層の確認
+        self.assertIn("=== BONE HIERARCHY", result)
+        if self.pmx_parser.bones:
+            # ボーンが存在する場合の確認
+            self.assertIn("[0]", result)  # インデックス表示
+
+    def test_dump_morphs(self):
+        """モーフ情報のダンプテスト"""
+        result = self.dumper.dump(sections=["morphs"])
+        
+        # モーフ情報の確認
+        self.assertIn("=== MORPHS", result)
+        if self.pmx_parser.morphs:
+            self.assertIn("Morph Types:", result)
+
+    def test_dump_materials(self):
+        """材質情報のダンプテスト"""
+        result = self.dumper.dump(sections=["materials"])
+        
+        # 材質情報の確認
+        self.assertIn("=== MATERIALS", result)
+        if self.pmx_parser.materials:
+            self.assertIn("Diffuse:", result)
+            self.assertIn("Specular:", result)
+
+    def test_dump_physics(self):
+        """物理演算情報のダンプテスト"""
+        result = self.dumper.dump(sections=["physics"])
+        
+        # 物理演算情報の確認
+        self.assertIn("=== PHYSICS ===", result)
+        self.assertIn("Rigid Bodies:", result)
+        self.assertIn("Joints:", result)
+
+    def test_dump_vertices_verbose(self):
+        """頂点情報のダンプテスト（verboseモード）"""
+        result = self.dumper.dump(sections=["vertices"], verbose=True)
+        
+        if self.pmx_parser.vertices:
+            # 頂点情報の確認
+            self.assertIn("=== VERTICES", result)
+            self.assertIn("Position Range:", result)
+            self.assertIn("Vertex Samples:", result)
+
+    def test_dump_all_sections(self):
+        """全セクションのダンプテスト"""
+        result = self.dumper.dump()
+        
+        # デフォルトセクションが含まれているか確認
+        self.assertIn("=== PMX MODEL DEBUG DUMP ===", result)
+        self.assertIn("=== STATISTICS ===", result)
+        self.assertIn("=== BONE HIERARCHY", result)
+        self.assertIn("=== MORPHS", result)
+        self.assertIn("=== MATERIALS", result)
+        self.assertIn("=== PHYSICS ===", result)
+
+    def test_dump_to_file(self):
+        """ファイルへの出力テスト"""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as f:
+            temp_path = f.name
+            self.dumper.dump(output=f)
+        
+        # ファイルが作成されたか確認
+        self.assertTrue(os.path.exists(temp_path))
+        
+        # 内容を確認
+        with open(temp_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+            self.assertIn("=== PMX MODEL DEBUG DUMP ===", content)
+        
+        # クリーンアップ
+        os.unlink(temp_path)
+
+    def test_dump_with_error_handling(self):
+        """エラーハンドリングのテスト"""
+        # 不正なデータでダンパーを作成（属性を削除）
+        dumper = PmxDumper(self.pmx_parser)
+        
+        # ヘッダーに存在しない属性を参照するようにして、エラーを発生させる
+        del dumper.pmx.header.model_name_english
+        
+        result = dumper.dump(sections=["header"])
+        
+        # エラーが適切に処理されているか確認
+        self.assertIn("[ERROR]", result)
+
+    def test_verbose_mode(self):
+        """詳細モードのテスト"""
+        result_normal = self.dumper.dump(sections=["header"], verbose=False)
+        result_verbose = self.dumper.dump(sections=["header"], verbose=True)
+        
+        # verboseモードでより多くの情報が含まれているか確認
+        self.assertGreater(len(result_verbose), len(result_normal))
+        self.assertIn("Index Sizes:", result_verbose)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- mmd_tools/utils/ を mmd_tools/tools/ にリネーム
- scripts/dump_pmx.py を tests/dump_pmx.py に移動
- 関連するインポートパスを更新
- PMXダンパーの動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)