### PR TITLE
refactor(ui): #80 Qt アーキテクチャ — Action / Service 層を抽出 (PR1-5)

### DIFF
--- a/mmd_tools/actions/__init__.py
+++ b/mmd_tools/actions/__init__.py
@@ -1,9 +1,17 @@
 """User action boundaries for UI presenter workflows."""
 
+from .export_model_action import (
+    ExportModelAction,
+    ExportModelRequest,
+    ExportModelResult,
+)
 from .import_model_action import ImportModelAction, ImportModelRequest, ImportModelResult
 from .import_vmd_action import ImportVmdAction, ImportVmdRequest, ImportVmdResult
 
 __all__ = [
+    "ExportModelAction",
+    "ExportModelRequest",
+    "ExportModelResult",
     "ImportModelAction",
     "ImportModelRequest",
     "ImportModelResult",

--- a/mmd_tools/actions/__init__.py
+++ b/mmd_tools/actions/__init__.py
@@ -1,0 +1,2 @@
+"""User action boundaries for UI presenter workflows."""
+

--- a/mmd_tools/actions/__init__.py
+++ b/mmd_tools/actions/__init__.py
@@ -1,2 +1,13 @@
 """User action boundaries for UI presenter workflows."""
 
+from .import_model_action import ImportModelAction, ImportModelRequest, ImportModelResult
+from .import_vmd_action import ImportVmdAction, ImportVmdRequest, ImportVmdResult
+
+__all__ = [
+    "ImportModelAction",
+    "ImportModelRequest",
+    "ImportModelResult",
+    "ImportVmdAction",
+    "ImportVmdRequest",
+    "ImportVmdResult",
+]

--- a/mmd_tools/actions/export_model_action.py
+++ b/mmd_tools/actions/export_model_action.py
@@ -1,0 +1,43 @@
+"""Action boundary for PMX/PMD model export execution."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from ..core.logger import get_logger
+
+logger = get_logger(__name__)
+
+_EXPORT_NOT_IMPLEMENTED_WARNING = "PMX export is not implemented yet (scene data collection missing)"
+_EXPORT_NOT_IMPLEMENTED_STATUS = "PMX export is not implemented yet (scene data collection is unsupported)"
+
+
+@dataclass
+class ExportModelRequest:
+    """Request data for exporting a PMX/PMD model."""
+
+    file_path: str
+    options: Dict[str, Any]
+
+
+@dataclass
+class ExportModelResult:
+    """Result data returned by PMX/PMD model export."""
+
+    exported_path: Optional[str] = None
+    succeeded: bool = False
+    status_message: str = ""
+    error: Optional[Exception] = None
+
+
+class ExportModelAction:
+    """Represent the Maya-side PMX/PMD model export boundary.
+
+    Scene data collection is not implemented yet, so this action deliberately
+    does not call an exporter. It preserves the current honest UI behavior while
+    providing the future insertion point for scene collection and export.
+    """
+
+    def execute(self, request: ExportModelRequest) -> ExportModelResult:
+        """Report the current unsupported export state without exporting."""
+        logger.warning(_EXPORT_NOT_IMPLEMENTED_WARNING)
+        return ExportModelResult(status_message=_EXPORT_NOT_IMPLEMENTED_STATUS)

--- a/mmd_tools/actions/import_model_action.py
+++ b/mmd_tools/actions/import_model_action.py
@@ -1,0 +1,53 @@
+"""Action boundary for PMX/PMD model import execution."""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from ..io.mmd_importer import import_mmd_file
+
+
+@dataclass
+class ImportModelRequest:
+    """Request data for importing a PMX/PMD model."""
+
+    file_path: str
+    options: Dict[str, Any]
+    create_new_scene: bool = False
+
+
+@dataclass
+class ImportModelResult:
+    """Result data returned by PMX/PMD model import."""
+
+    root_node: Any = None
+    succeeded: bool = False
+    error: Optional[Exception] = None
+
+
+class ImportModelAction:
+    """Execute the Maya-side PMX/PMD model import."""
+
+    def __init__(
+        self,
+        importer: Optional[Callable[..., Any]] = None,
+        new_scene: Optional[Callable[[], None]] = None,
+    ):
+        self._importer = importer
+        self._new_scene = new_scene or self._create_new_scene
+
+    def execute(self, request: ImportModelRequest) -> ImportModelResult:
+        """Run model import and convert backend failures into a result object."""
+        try:
+            if request.create_new_scene:
+                self._new_scene()
+            importer = self._importer or import_mmd_file
+            root_node = importer(request.file_path, options=request.options)
+        except Exception as exc:
+            return ImportModelResult(error=exc)
+        return ImportModelResult(root_node=root_node, succeeded=bool(root_node))
+
+    @staticmethod
+    def _create_new_scene() -> None:
+        from maya import cmds
+
+        cmds.file(new=True, force=True)

--- a/mmd_tools/actions/import_vmd_action.py
+++ b/mmd_tools/actions/import_vmd_action.py
@@ -1,0 +1,53 @@
+"""Action boundary for VMD animation import execution."""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from ..io.mmd_importer import import_mmd_file
+
+
+@dataclass
+class ImportVmdRequest:
+    """Request data for importing a VMD animation."""
+
+    file_path: str
+    options: Dict[str, Any]
+    create_new_scene: bool = False
+
+
+@dataclass
+class ImportVmdResult:
+    """Result data returned by VMD animation import."""
+
+    root_node: Any = None
+    succeeded: bool = False
+    error: Optional[Exception] = None
+
+
+class ImportVmdAction:
+    """Execute the Maya-side VMD animation import."""
+
+    def __init__(
+        self,
+        importer: Optional[Callable[..., Any]] = None,
+        new_scene: Optional[Callable[[], None]] = None,
+    ):
+        self._importer = importer
+        self._new_scene = new_scene or self._create_new_scene
+
+    def execute(self, request: ImportVmdRequest) -> ImportVmdResult:
+        """Run VMD import and convert backend failures into a result object."""
+        try:
+            if request.create_new_scene:
+                self._new_scene()
+            importer = self._importer or import_mmd_file
+            root_node = importer(request.file_path, options=request.options)
+        except Exception as exc:
+            return ImportVmdResult(error=exc)
+        return ImportVmdResult(root_node=root_node, succeeded=bool(root_node))
+
+    @staticmethod
+    def _create_new_scene() -> None:
+        from maya import cmds
+
+        cmds.file(new=True, force=True)

--- a/mmd_tools/services/__init__.py
+++ b/mmd_tools/services/__init__.py
@@ -1,0 +1,2 @@
+"""Application-level services for maya_mmd_tools."""
+

--- a/mmd_tools/services/scene_model_service.py
+++ b/mmd_tools/services/scene_model_service.py
@@ -1,0 +1,169 @@
+"""Mayaシーン内のMMDモデル状態を取得するサービス。
+
+ApplicationStateやPresenterがMayaコマンドへ直接依存しすぎないように、
+モデル列挙・選択解決・概要情報収集を集約します。
+"""
+
+from ..core.constants import ATTR_MMD_MODEL_NAME, ATTR_MMD_MODEL_NAME_EN, SCENE_ROOT_SUFFIX
+from ..core.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class SceneModelService:
+    """MayaシーンからMMDモデルに関する状態を読み取るサービス。"""
+
+    def __init__(self, cmds_module=None):
+        if cmds_module is None:
+            from maya import cmds as maya_cmds
+
+            cmds_module = maya_cmds
+        self._cmds = cmds_module
+
+    def object_exists(self, node):
+        """ノードが存在するかを返す。"""
+        if not node:
+            return False
+        return bool(self._cmds.objExists(node))
+
+    def list_mmd_models(self):
+        """シーン内のMMDモデル root を名前順で返す。"""
+        namespaced = self._cmds.ls("*:*{}".format(SCENE_ROOT_SUFFIX), type="transform") or []
+        plain = self._cmds.ls("*{}".format(SCENE_ROOT_SUFFIX), type="transform") or []
+
+        mmd_models = []
+        for transform in set(namespaced + plain):
+            if self._cmds.attributeQuery(ATTR_MMD_MODEL_NAME, node=transform, exists=True) or self._cmds.attributeQuery(
+                ATTR_MMD_MODEL_NAME_EN, node=transform, exists=True
+            ):
+                mmd_models.append(transform)
+
+        return sorted(mmd_models)
+
+    def get_parent_mmd_root(self, node):
+        """指定ノードの親階層からMMDモデル root を探す。"""
+        try:
+            current = node
+            while current:
+                if current.endswith(SCENE_ROOT_SUFFIX) and (
+                    self._cmds.attributeQuery(ATTR_MMD_MODEL_NAME, node=current, exists=True)
+                    or self._cmds.attributeQuery(ATTR_MMD_MODEL_NAME_EN, node=current, exists=True)
+                ):
+                    return current
+
+                parents = self._cmds.listRelatives(current, parent=True, fullPath=True) or []
+                if not parents:
+                    break
+                current = parents[0]
+        except Exception as e:
+            logger.warning(f"Failed to find parent MMD root for {node}: {e}")
+
+        return None
+
+    def get_model_display_name(self, model_root):
+        """MMDモデルの表示名を返す。"""
+        try:
+            if self._cmds.attributeQuery(ATTR_MMD_MODEL_NAME, node=model_root, exists=True):
+                name_jp = self._cmds.getAttr(f"{model_root}.{ATTR_MMD_MODEL_NAME}")
+                if name_jp:
+                    return name_jp
+
+            if self._cmds.attributeQuery(ATTR_MMD_MODEL_NAME_EN, node=model_root, exists=True):
+                name_en = self._cmds.getAttr(f"{model_root}.{ATTR_MMD_MODEL_NAME_EN}")
+                if name_en:
+                    return name_en
+        except Exception:
+            pass
+
+        return model_root.replace(SCENE_ROOT_SUFFIX, "")
+
+    def get_selected_nodes(self, node_type=None):
+        """Mayaの現在選択を返す。"""
+        if node_type:
+            return self._cmds.ls(selection=True, type=node_type) or []
+        return self._cmds.ls(selection=True) or []
+
+    def resolve_model_from_selection(self, available_models):
+        """現在選択から、available_models に含まれるMMDモデル root を推測する。"""
+        selected = self.get_selected_nodes()
+        if not selected:
+            return None
+
+        for obj in selected:
+            parent_root = self.get_parent_mmd_root(obj)
+            if not parent_root:
+                continue
+
+            short_name = parent_root.split("|")[-1]
+            if parent_root in available_models:
+                return parent_root
+            if short_name in available_models:
+                return short_name
+
+        return None
+
+    def get_model_info(self, model_root):
+        """モデル概要情報を収集する。"""
+        if not model_root or not self.object_exists(model_root):
+            return None
+
+        try:
+            namespace = None
+            if ":" in model_root:
+                namespace = model_root.rsplit(":", 1)[0]
+                if "|" in namespace:
+                    namespace = namespace.split("|")[-1]
+
+            info = {
+                "root": model_root,
+                "namespace": namespace,
+                "display_name": self.get_model_display_name(model_root),
+                "name_jp": self.get_attr_safe(model_root, ATTR_MMD_MODEL_NAME, ""),
+                "name_en": self.get_attr_safe(model_root, ATTR_MMD_MODEL_NAME_EN, ""),
+                "vertex_count": 0,
+                "material_count": 0,
+                "bone_count": 0,
+                "morph_count": 0,
+            }
+
+            shapes = self._cmds.listRelatives(model_root, allDescendents=True, type="mesh") or []
+            for shape in shapes:
+                vertex_count = self._cmds.polyEvaluate(shape, vertex=True)
+                if vertex_count:
+                    info["vertex_count"] += vertex_count
+
+            if shapes:
+                shading_groups = self._cmds.listConnections(shapes, type="shadingEngine") or []
+                materials = []
+                for sg in set(shading_groups):
+                    mats = self._cmds.ls(self._cmds.listConnections(sg), materials=True) or []
+                    materials.extend(mats)
+                info["material_count"] = len(set(materials))
+
+            joints = self._cmds.listRelatives(model_root, allDescendents=True, type="joint") or []
+            info["bone_count"] = len(joints)
+
+            if shapes:
+                blend_shapes = self._cmds.ls(self._cmds.listHistory(shapes), type="blendShape") or []
+                for blend_shape in blend_shapes:
+                    targets = self._cmds.blendShape(blend_shape, query=True, target=True) or []
+                    info["morph_count"] += len(targets)
+
+            return info
+        except Exception as e:
+            logger.error(f"Failed to get model info for {model_root}: {e}", exc_info=True)
+            return None
+
+    def get_attr_safe(self, node, attr, default=None):
+        """属性値を安全に取得する。"""
+        try:
+            if self._cmds.attributeQuery(attr, node=node, exists=True):
+                value = self._cmds.getAttr(f"{node}.{attr}")
+                return value if value is not None else default
+        except Exception:
+            pass
+        return default
+
+    def select_nodes(self, nodes, replace=True):
+        """ノードを選択する。"""
+        self._cmds.select(nodes, replace=replace)

--- a/mmd_tools/services/settings_service.py
+++ b/mmd_tools/services/settings_service.py
@@ -1,0 +1,172 @@
+"""Settings application service for presenters.
+
+This module keeps UI presenters independent from the core settings singleton
+while preserving the existing optionVar-backed storage behavior.
+"""
+
+import json
+
+from ..core.settings import get_settings
+
+
+_SETTINGS_EXPORT_CATEGORIES = ("import", "export", "logging", "ui")
+
+# Dev-only import keys: forced to these values in normal mode (development_mode=False).
+# In dev mode the saved setting is used instead.
+_NORMAL_MODE_IMPORT_OVERRIDES = {
+    "import_models": True,
+    "import_physics": False,
+    "separate_meshes_by_material": False,
+    "split_meshes_by_morph_groups": False,
+    "hide_hidden_geometry": False,
+    "auto_classify_transparency": False,
+    "disable_backface_culling": True,
+    "uv_set_name": "map#",
+    "texture_search_path": "",
+    "add_semi_standard_bones": False,
+    "translate_names": True,
+}
+
+
+class SettingsService:
+    """Presenter-facing API for plugin settings."""
+
+    def __init__(self, settings_store=None):
+        self._settings = settings_store if settings_store is not None else get_settings()
+
+    @property
+    def data(self):
+        """Return the underlying nested settings dictionary."""
+        return self._settings.data
+
+    def get(self, key_path, default=None):
+        """Read a setting by dot-separated key path."""
+        return self._settings.get(key_path, default)
+
+    def set(self, key_path, value):
+        """Write a setting by dot-separated key path."""
+        self._settings.set(key_path, value)
+
+    def save(self):
+        """Persist the current settings store."""
+        self._settings.save()
+
+    def reset(self):
+        """Reset the current settings store to JSON defaults."""
+        self._settings.reset()
+
+    def is_development_mode(self):
+        """Return whether Development Mode is enabled."""
+        return self.get("ui.general.development_mode", False)
+
+    def set_development_mode_log_levels(self, enabled):
+        """Set UI and logging levels for Development Mode and return the level."""
+        level_str = "INFO" if enabled else "WARNING"
+        self.set("ui.general.log_level", level_str)
+        self.set("logging.level", level_str)
+        return level_str
+
+    def load_settings_tab_state(self):
+        """Return settings needed by the Settings tab view."""
+        return {
+            "development_mode": self.get("ui.general.development_mode", False),
+            "ui_log_level": self.get("ui.general.log_level", "WARNING"),
+            "logging_enabled": self.get("logging.enabled", True),
+            "logging_level": self.get("logging.level", "DEBUG"),
+            "log_file_path": self.get("logging.log_file_path", "logs/mmd_tools.log"),
+            "language": self.get("ui.general.language", "ja"),
+        }
+
+    def save_settings_tab_state(self, state):
+        """Persist settings supplied by the Settings tab presenter."""
+        self.set("ui.general.development_mode", state["development_mode"])
+        self.set("ui.general.log_level", state["ui_log_level"])
+        if "language" in state:
+            self.set("ui.general.language", state["language"])
+        self.set("logging.enabled", state["logging_enabled"])
+        self.set("logging.level", state["logging_level"])
+        self.set("logging.log_file_path", state["log_file_path"])
+        self.save()
+
+    def export_settings_data(self):
+        """Return the JSON-exportable settings categories."""
+        all_settings = self.data
+        return {category: all_settings.get(category, {}) for category in _SETTINGS_EXPORT_CATEGORIES}
+
+    def write_settings_json(self, file_path):
+        """Write exportable settings to a JSON file."""
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(self.export_settings_data(), f, ensure_ascii=False, indent=2)
+
+    def read_settings_json(self, file_path):
+        """Read settings JSON from a file."""
+        with open(file_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def import_settings_data(self, data):
+        """Import settings data for supported top-level categories."""
+        for category in _SETTINGS_EXPORT_CATEGORIES:
+            if category in data:
+                for key, value in data[category].items():
+                    self.set(f"{category}.{key}", value)
+
+    def import_settings_json(self, file_path):
+        """Read and import settings from a JSON file."""
+        self.import_settings_data(self.read_settings_json(file_path))
+
+    def build_vmd_import_options(self, target_model=None):
+        """Build VMD import options from persisted settings."""
+        is_dev = self.is_development_mode()
+        return {
+            "start_frame": self.get("import.animation.animation_start_frame", 1),
+            "vmd_fps": self.get("import.animation.vmd_fps", 30),
+            "import_bone_animation": self.get("import.animation.import_animations", True),
+            "import_morph_animation": self.get("import.animation.import_morph_animation", True),
+            "import_camera_animation": self.get("import.animation.import_camera_animation", True),
+            "import_light_animation": self.get("import.animation.import_light_animation", True),
+            "resample_curves": self.get("import.animation.resample_curves", False) if is_dev else False,
+            "target_model": target_model,
+        }
+
+    def build_pmx_import_options(self, custom_namespace=None):
+        """Build PMX/PMD import options from persisted settings."""
+        is_dev = self.is_development_mode()
+        opts = {
+            "scale": self.get("import.general.scale_factor", 1.0),
+            "use_namespace": self.get("import.general.use_namespace", False),
+            "custom_namespace": custom_namespace,
+            "import_models": self.get("import.model.import_models", True),
+            "create_mmd_shaders": self.get("import.model.create_mmd_shaders", True),
+            "separate_meshes_by_material": self.get("import.model.separate_meshes_by_material", False),
+            "split_meshes_by_morph_groups": self.get("import.model.split_meshes_by_morph_groups", False),
+            "hide_hidden_geometry": self.get("import.model.hide_hidden_geometry", False),
+            "auto_classify_transparency": self.get("import.model.auto_classify_transparency", False),
+            "disable_backface_culling": self.get("import.model.disable_backface_culling", True),
+            "uv_set_name": self.get("import.model.uv_set_name", "map#"),
+            "texture_search_path": self.get("import.model.texture_search_path", ""),
+            "import_physics": self.get("import.physics.import_physics", False),
+            "import_morphs": self.get("import.morph.import_morphs", True),
+            "add_semi_standard_bones": self.get("import.rig.add_semi_standard_bones", False),
+            "translate_names": self.get("import.naming.translate_names", True),
+        }
+        if not is_dev:
+            opts.update(_NORMAL_MODE_IMPORT_OVERRIDES)
+        bake_mode = self.get("import.rig.bake_mode", True) if is_dev else True
+        if bake_mode:
+            opts["setup_rig"] = False
+            opts["setup_bone_orientation"] = False
+        opts["use_cpp_fast_load"] = self.get("import.native.use_cpp_fast_load", False)
+        opts["cpp_fast_load_mesh_only"] = self.get("import.native.cpp_fast_load_mesh_only", True)
+        return opts
+
+    def should_show_texture_issue_dialog(self):
+        """Return whether post-import texture issue diagnostics should be shown."""
+        return self.get("import.model.show_texture_issue_dialog", True)
+
+    def build_export_options(self, file_path):
+        """Build PMX/PMD export options from persisted settings."""
+        return {
+            "file_path": file_path,
+            "export_format": self.get("export.general.export_format", "pmx"),
+            "apply_scale": self.get("export.general.apply_scale", True),
+        }

--- a/mmd_tools/ui/application_state.py
+++ b/mmd_tools/ui/application_state.py
@@ -3,14 +3,8 @@
 全てのタブ間で共有される情報を一元管理します
 """
 
-from maya import cmds
-from mmd_tools.core.constants import ATTR_MMD_MODEL_NAME_EN, ATTR_MMD_MODEL_NAME
 from ..core.logger import get_logger
-from ..core.maya_utils import (
-    find_all_mmd_models,
-    get_mmd_model_display_name,
-    get_parent_mmd_root,
-)
+from ..services.scene_model_service import SceneModelService
 from .qt_compat import QObject, Signal
 
 logger = get_logger(__name__)
@@ -25,8 +19,9 @@ class ApplicationState(QObject):
     status_message = Signal(str)  # ステータスメッセージ
     progress_updated = Signal(int)  # 進捗状況 (0-100)
 
-    def __init__(self):
+    def __init__(self, scene_model_service=None):
         super().__init__()
+        self._scene_model_service = scene_model_service if scene_model_service is not None else SceneModelService()
         self._current_model_root = None
         self._available_models = []
         self._model_info_cache = {}  # モデル情報のキャッシュ
@@ -43,14 +38,16 @@ class ApplicationState(QObject):
         if value != self._current_model_root:
             old_value = self._current_model_root
             self._current_model_root = value
+            invalid_model_root = False
 
             # 存在チェック
-            if value and not cmds.objExists(value):
+            if value and not self._scene_model_service.object_exists(value):
                 logger.warning(f"Model root '{value}' does not exist")
                 self._current_model_root = None
                 value = None
+                invalid_model_root = True
 
-            if old_value != self._current_model_root:
+            if old_value != self._current_model_root or invalid_model_root:
                 logger.info(f"Current model changed: {old_value} -> {self._current_model_root}")
                 self.current_model_changed.emit(self._current_model_root or "")
 
@@ -67,7 +64,7 @@ class ApplicationState(QObject):
         """シーン内のMMDモデルリストを更新"""
         try:
             old_models = self._available_models.copy()
-            self._available_models = find_all_mmd_models()
+            self._available_models = self._scene_model_service.list_mmd_models()
 
             if old_models != self._available_models:
                 logger.info(f"Model list updated: {len(self._available_models)} models found")
@@ -92,31 +89,19 @@ class ApplicationState(QObject):
 
     def select_model_from_maya_selection(self):
         """Mayaの選択からモデルを推測して選択"""
-        selected = cmds.ls(selection=True)
-        if not selected:
+        model_root = self._scene_model_service.resolve_model_from_selection(self._available_models)
+        if not model_root:
             return False
 
-        for obj in selected:
-            parent_root = get_parent_mmd_root(obj)
-            if parent_root:
-                # 完全パスと短い名前の両方をチェック
-                short_name = parent_root.split("|")[-1]
-                if parent_root in self._available_models or short_name in self._available_models:
-                    # available_modelsにある形式で設定
-                    if parent_root in self._available_models:
-                        self.current_model_root = parent_root
-                    else:
-                        self.current_model_root = short_name
-                    return True
-
-        return False
+        self.current_model_root = model_root
+        return True
 
     def get_model_info(self, model_root=None):
         """モデル情報を取得（キャッシュ使用）"""
         if model_root is None:
             model_root = self._current_model_root
 
-        if not model_root or not cmds.objExists(model_root):
+        if not model_root or not self._scene_model_service.object_exists(model_root):
             return None
 
         # キャッシュチェック
@@ -129,73 +114,7 @@ class ApplicationState(QObject):
 
     def _cache_model_info(self, model_root):
         """モデル情報をキャッシュ"""
-        try:
-            # namespace情報を取得
-            namespace = None
-            if ":" in model_root:
-                # 最後の':'より前がnamespace
-                namespace = model_root.rsplit(":", 1)[0]
-                # パイプが含まれている場合は最後の要素を取得
-                if "|" in namespace:
-                    namespace = namespace.split("|")[-1]
-
-            info = {
-                "root": model_root,
-                "namespace": namespace,
-                "display_name": get_mmd_model_display_name(model_root),
-                "name_jp": self._get_attr_safe(model_root, ATTR_MMD_MODEL_NAME, ""),
-                "name_en": self._get_attr_safe(model_root, ATTR_MMD_MODEL_NAME_EN, ""),
-                "vertex_count": 0,
-                "material_count": 0,
-                "bone_count": 0,
-                "morph_count": 0,
-            }
-
-            # 統計情報を収集
-            if cmds.objExists(model_root):
-                # メッシュ情報
-                shapes = cmds.listRelatives(model_root, allDescendents=True, type="mesh") or []
-                for shape in shapes:
-                    vertex_count = cmds.polyEvaluate(shape, vertex=True)
-                    if vertex_count:
-                        info["vertex_count"] += vertex_count
-
-                # マテリアル数
-                if shapes:
-                    shading_groups = cmds.listConnections(shapes, type="shadingEngine") or []
-                    shading_groups = list(set(shading_groups))
-                    materials = []
-                    for sg in shading_groups:
-                        mats = cmds.ls(cmds.listConnections(sg), materials=True) or []
-                        materials.extend(mats)
-                    info["material_count"] = len(set(materials))
-
-                # ボーン数
-                joints = cmds.listRelatives(model_root, allDescendents=True, type="joint") or []
-                info["bone_count"] = len(joints)
-
-                # モーフ数（ブレンドシェイプ）
-                if shapes:
-                    blend_shapes = cmds.ls(cmds.listHistory(shapes), type="blendShape") or []
-                    for bs in blend_shapes:
-                        targets = cmds.blendShape(bs, query=True, target=True) or []
-                        info["morph_count"] += len(targets)
-
-            self._model_info_cache[model_root] = info
-
-        except Exception as e:
-            logger.error(f"Failed to cache model info for {model_root}: {e}", exc_info=True)
-            self._model_info_cache[model_root] = None
-
-    def _get_attr_safe(self, node, attr, default):
-        """属性を安全に取得"""
-        try:
-            if cmds.attributeQuery(attr, node=node, exists=True):
-                value = cmds.getAttr(f"{node}.{attr}")
-                return value if value is not None else default
-        except Exception:
-            pass
-        return default
+        self._model_info_cache[model_root] = self._scene_model_service.get_model_info(model_root)
 
     def clear_cache(self):
         """キャッシュをクリア"""

--- a/mmd_tools/ui/presenters/import_export_presenter.py
+++ b/mmd_tools/ui/presenters/import_export_presenter.py
@@ -4,25 +4,9 @@ from ...actions.import_model_action import ImportModelAction, ImportModelRequest
 from ...actions.import_vmd_action import ImportVmdAction, ImportVmdRequest
 from ...core.logger import get_logger
 from ...io.mmd_importer import import_mmd_file
-from ...core.settings import settings
+from ...services.settings_service import SettingsService
 
 logger = get_logger(__name__)
-
-# Dev-only import keys: forced to these values in normal mode (development_mode=False).
-# In dev mode the saved setting is used instead.
-_NORMAL_MODE_IMPORT_OVERRIDES = {
-    "import_models": True,
-    "import_physics": False,
-    "separate_meshes_by_material": False,
-    "split_meshes_by_morph_groups": False,
-    "hide_hidden_geometry": False,
-    "auto_classify_transparency": False,
-    "disable_backface_culling": True,
-    "uv_set_name": "map#",
-    "texture_search_path": "",
-    "add_semi_standard_bones": False,
-    "translate_names": True,
-}
 
 
 class ImportExportPresenter(QObject):
@@ -33,6 +17,7 @@ class ImportExportPresenter(QObject):
         import_model_action=None,
         import_vmd_action=None,
         export_model_action=None,
+        settings_service=None,
     ):
         super().__init__()
         self.view = view
@@ -40,6 +25,7 @@ class ImportExportPresenter(QObject):
         self.import_model_action = import_model_action or ImportModelAction()
         self.import_vmd_action = import_vmd_action or ImportVmdAction()
         self.export_model_action = export_model_action or ExportModelAction()
+        self.settings_service = settings_service or SettingsService()
         self.connect_signals()
 
     def connect_signals(self):
@@ -87,57 +73,20 @@ class ImportExportPresenter(QObject):
         """VMD import用のオプションをUI設定から組み立てる。"""
         if target_model is None:
             target_model = self._get_vmd_target_model()
-        is_dev = settings.get("ui.general.development_mode", False)
-        return {
-            "start_frame": settings.get("import.animation.animation_start_frame", 1),
-            "vmd_fps": settings.get("import.animation.vmd_fps", 30),
-            "import_bone_animation": settings.get("import.animation.import_animations", True),
-            "import_morph_animation": settings.get("import.animation.import_morph_animation", True),
-            "import_camera_animation": settings.get("import.animation.import_camera_animation", True),
-            "import_light_animation": settings.get("import.animation.import_light_animation", True),
-            "resample_curves": settings.get("import.animation.resample_curves", False) if is_dev else False,
-            "target_model": target_model,
-        }
+        return self.settings_service.build_vmd_import_options(target_model)
 
     def _build_pmx_import_options(self):
         """PMX/PMD import用のオプションを組み立てる。
 
         通常モード（development_mode=False）では dev-only 設定を強制デフォルトに上書きする。
         """
-        is_dev = settings.get("ui.general.development_mode", False)
-        opts = {
-            "scale": settings.get("import.general.scale_factor", 1.0),
-            "use_namespace": settings.get("import.general.use_namespace", False),
-            "custom_namespace": self.view.get_custom_namespace(),
-            "import_models": settings.get("import.model.import_models", True),
-            "create_mmd_shaders": settings.get("import.model.create_mmd_shaders", True),
-            "separate_meshes_by_material": settings.get("import.model.separate_meshes_by_material", False),
-            "split_meshes_by_morph_groups": settings.get("import.model.split_meshes_by_morph_groups", False),
-            "hide_hidden_geometry": settings.get("import.model.hide_hidden_geometry", False),
-            "auto_classify_transparency": settings.get("import.model.auto_classify_transparency", False),
-            "disable_backface_culling": settings.get("import.model.disable_backface_culling", True),
-            "uv_set_name": settings.get("import.model.uv_set_name", "map#"),
-            "texture_search_path": settings.get("import.model.texture_search_path", ""),
-            "import_physics": settings.get("import.physics.import_physics", False),
-            "import_morphs": settings.get("import.morph.import_morphs", True),
-            "add_semi_standard_bones": settings.get("import.rig.add_semi_standard_bones", False),
-            "translate_names": settings.get("import.naming.translate_names", True),
-        }
-        if not is_dev:
-            opts.update(_NORMAL_MODE_IMPORT_OVERRIDES)
-        bake_mode = settings.get("import.rig.bake_mode", True) if is_dev else True
-        if bake_mode:
-            opts["setup_rig"] = False
-            opts["setup_bone_orientation"] = False
-        opts["use_cpp_fast_load"] = settings.get("import.native.use_cpp_fast_load", False)
-        opts["cpp_fast_load_mesh_only"] = settings.get("import.native.cpp_fast_load_mesh_only", True)
-        return opts
+        return self.settings_service.build_pmx_import_options(self.view.get_custom_namespace())
 
     def _maybe_show_texture_issue_dialog(self, profile, file_path):
         """Show post-import texture issues for UI-triggered PMX/PMD imports."""
 
         issues = profile.get("texture_issues") or profile.get("mesh_converter", {}).get("unresolved_textures") or []
-        if not issues or not settings.get("import.model.show_texture_issue_dialog", True):
+        if not issues or not self.settings_service.should_show_texture_issue_dialog():
             return
         try:
             from ..texture_issue_dialog import TextureIssueDialog
@@ -152,11 +101,7 @@ class ImportExportPresenter(QObject):
 
     def _build_export_options(self):
         """PMX/PMD export用の基本オプションを設定から組み立てる。"""
-        return {
-            "file_path": self.view.export_path_edit.text().strip(),
-            "export_format": settings.get("export.general.export_format", "pmx"),
-            "apply_scale": settings.get("export.general.apply_scale", True),
-        }
+        return self.settings_service.build_export_options(self.view.export_path_edit.text().strip())
 
     def import_file(self):
         file_path = self.view.import_path_edit.text().strip()

--- a/mmd_tools/ui/presenters/import_export_presenter.py
+++ b/mmd_tools/ui/presenters/import_export_presenter.py
@@ -1,5 +1,6 @@
 from ..qt_compat import QObject, QFileDialog
 from ...actions.import_model_action import ImportModelAction, ImportModelRequest
+from ...actions.import_vmd_action import ImportVmdAction, ImportVmdRequest
 from ...core.logger import get_logger
 from ...io.mmd_importer import import_mmd_file
 from ...core.settings import settings
@@ -24,11 +25,12 @@ _NORMAL_MODE_IMPORT_OVERRIDES = {
 
 
 class ImportExportPresenter(QObject):
-    def __init__(self, view, app_state, import_model_action=None):
+    def __init__(self, view, app_state, import_model_action=None, import_vmd_action=None):
         super().__init__()
         self.view = view
         self.app_state = app_state
         self.import_model_action = import_model_action or ImportModelAction()
+        self.import_vmd_action = import_vmd_action or ImportVmdAction()
         self.connect_signals()
 
     def connect_signals(self):
@@ -155,11 +157,6 @@ class ImportExportPresenter(QObject):
 
         create_new_scene = hasattr(self.view, "new_file_check") and self.view.new_file_check.isChecked()
         is_vmd = file_path.lower().endswith(".vmd")
-        if is_vmd and create_new_scene:
-            from maya import cmds
-
-            cmds.file(new=True, force=True)
-            logger.info("Created new file before import")
 
         logger.info(f"Importing file: {file_path}")
 
@@ -176,7 +173,17 @@ class ImportExportPresenter(QObject):
 
         try:
             if is_vmd:
-                root_node = import_mmd_file(file_path, options=import_options)
+                request = ImportVmdRequest(
+                    file_path=file_path,
+                    options=import_options,
+                    create_new_scene=create_new_scene,
+                )
+                result = self.import_vmd_action.execute(request)
+                if result.error:
+                    raise result.error
+                root_node = result.root_node if result.succeeded else None
+                if create_new_scene:
+                    logger.info("Created new file before import")
             else:
                 request = ImportModelRequest(
                     file_path=file_path,

--- a/mmd_tools/ui/presenters/import_export_presenter.py
+++ b/mmd_tools/ui/presenters/import_export_presenter.py
@@ -1,4 +1,5 @@
 from ..qt_compat import QObject, QFileDialog
+from ...actions.export_model_action import ExportModelAction, ExportModelRequest
 from ...actions.import_model_action import ImportModelAction, ImportModelRequest
 from ...actions.import_vmd_action import ImportVmdAction, ImportVmdRequest
 from ...core.logger import get_logger
@@ -25,12 +26,20 @@ _NORMAL_MODE_IMPORT_OVERRIDES = {
 
 
 class ImportExportPresenter(QObject):
-    def __init__(self, view, app_state, import_model_action=None, import_vmd_action=None):
+    def __init__(
+        self,
+        view,
+        app_state,
+        import_model_action=None,
+        import_vmd_action=None,
+        export_model_action=None,
+    ):
         super().__init__()
         self.view = view
         self.app_state = app_state
         self.import_model_action = import_model_action or ImportModelAction()
         self.import_vmd_action = import_vmd_action or ImportVmdAction()
+        self.export_model_action = export_model_action or ExportModelAction()
         self.connect_signals()
 
     def connect_signals(self):
@@ -227,12 +236,14 @@ class ImportExportPresenter(QObject):
         export_options = self._build_export_options()
         logger.debug(f"Export options: {export_options}")
 
-        # NOTE: Maya シーンから PMX 用データ（頂点/面/材質/ボーン等）を収集する処理が
-        # 未実装。収集なしで PmxExporter を呼ぶと必ず ValueError になり、ユーザーに
-        # 紛らわしいエラーを見せてしまうため、現時点では未実装であることを明示する。
-        # シーン収集（collect_*_from_scene_for_export 等）を実装したら有効化する。
-        logger.warning("PMX export is not implemented yet (scene data collection missing)")
-        self.app_state.emit_status("PMX export is not implemented yet (scene data collection is unsupported)")
+        request = ExportModelRequest(file_path=file_path, options=export_options)
+        result = self.export_model_action.execute(request)
+        if result.error:
+            logger.error(f"Export failed: {result.error}")
+            self.app_state.emit_status(f"Export error: {str(result.error)}")
+            return
+        if result.status_message:
+            self.app_state.emit_status(result.status_message)
 
     def import_vmd_file(self):
         """VMDファイルのインポート"""

--- a/mmd_tools/ui/presenters/import_export_presenter.py
+++ b/mmd_tools/ui/presenters/import_export_presenter.py
@@ -1,4 +1,5 @@
 from ..qt_compat import QObject, QFileDialog
+from ...actions.import_model_action import ImportModelAction, ImportModelRequest
 from ...core.logger import get_logger
 from ...io.mmd_importer import import_mmd_file
 from ...core.settings import settings
@@ -23,10 +24,11 @@ _NORMAL_MODE_IMPORT_OVERRIDES = {
 
 
 class ImportExportPresenter(QObject):
-    def __init__(self, view, app_state):
+    def __init__(self, view, app_state, import_model_action=None):
         super().__init__()
         self.view = view
         self.app_state = app_state
+        self.import_model_action = import_model_action or ImportModelAction()
         self.connect_signals()
 
     def connect_signals(self):
@@ -151,8 +153,9 @@ class ImportExportPresenter(QObject):
             self.app_state.emit_status("Please enter a file path")
             return
 
-        # Check if new file is requested
-        if hasattr(self.view, "new_file_check") and self.view.new_file_check.isChecked():
+        create_new_scene = hasattr(self.view, "new_file_check") and self.view.new_file_check.isChecked()
+        is_vmd = file_path.lower().endswith(".vmd")
+        if is_vmd and create_new_scene:
             from maya import cmds
 
             cmds.file(new=True, force=True)
@@ -166,13 +169,26 @@ class ImportExportPresenter(QObject):
 
         import_options = self._build_pmx_import_options()
         import_profile = {}
-        if file_path.lower().endswith(".vmd"):
+        if is_vmd:
             import_options.update(self._build_vmd_import_options())
         else:
             import_options["profile"] = import_profile
 
         try:
-            root_node = import_mmd_file(file_path, options=import_options)
+            if is_vmd:
+                root_node = import_mmd_file(file_path, options=import_options)
+            else:
+                request = ImportModelRequest(
+                    file_path=file_path,
+                    options=import_options,
+                    create_new_scene=create_new_scene,
+                )
+                result = self.import_model_action.execute(request)
+                if result.error:
+                    raise result.error
+                root_node = result.root_node if result.succeeded else None
+                if create_new_scene:
+                    logger.info("Created new file before import")
             if root_node:
                 logger.info("Import successful.")
                 # ApplicationStateを更新
@@ -184,7 +200,7 @@ class ImportExportPresenter(QObject):
                 self.view.refresh_model_list()
                 # 成功したパスを履歴に追加
                 self.view.add_import_path_to_history(file_path)
-                if not file_path.lower().endswith(".vmd"):
+                if not is_vmd:
                     self._maybe_show_texture_issue_dialog(import_profile, file_path)
             else:
                 logger.error("Import failed.")

--- a/mmd_tools/ui/presenters/settings_presenter.py
+++ b/mmd_tools/ui/presenters/settings_presenter.py
@@ -1,16 +1,15 @@
-from ...core.logger import get_logger
-from ... import settings
-from ...core.settings import get_settings
 from ..qt_compat import QFileDialog, QMessageBox
-import json
+from ...core.logger import get_logger
+from ...services.settings_service import SettingsService
 
 logger = get_logger(__name__)
 
 
 class SettingsPresenter:
-    def __init__(self, view, app_state):
+    def __init__(self, view, app_state, settings_service=None):
         self.view = view
         self.app_state = app_state
+        self.settings_service = settings_service or SettingsService()
         self._loading = False
 
         # ウィジェットの存在を確認
@@ -65,24 +64,25 @@ class SettingsPresenter:
         self._loading = True
 
         try:
+            state = self.settings_service.load_settings_tab_state()
             # UI設定
-            self.view.development_mode_check.setChecked(settings.get("ui.general.development_mode", False))
-            ui_log_level = settings.get("ui.general.log_level", "WARNING")
+            self.view.development_mode_check.setChecked(state["development_mode"])
+            ui_log_level = state["ui_log_level"]
             index = self.view.ui_log_level_combo.findText(ui_log_level)
             if index >= 0:
                 self.view.ui_log_level_combo.setCurrentIndex(index)
 
             # ログ設定
-            self.view.logging_enabled_check.setChecked(settings.get("logging.enabled", True))
-            log_level = settings.get("logging.level", "DEBUG")
+            self.view.logging_enabled_check.setChecked(state["logging_enabled"])
+            log_level = state["logging_level"]
             index = self.view.log_level_combo.findText(log_level)
             if index >= 0:
                 self.view.log_level_combo.setCurrentIndex(index)
-            self.view.log_file_path_edit.setText(settings.get("logging.log_file_path", "logs/mmd_tools.log"))
+            self.view.log_file_path_edit.setText(state["log_file_path"])
 
             # 言語設定
             if hasattr(self.view, "language_combo"):
-                current_language = settings.get("ui.general.language", "ja")
+                current_language = state["language"]
                 for i in range(self.view.language_combo.count()):
                     if self.view.language_combo.itemData(i) == current_language:
                         self.view.language_combo.setCurrentIndex(i)
@@ -105,17 +105,13 @@ class SettingsPresenter:
         import logging
 
         dev_on = self.view.development_mode_check.isChecked()
-        level_str = "INFO" if dev_on else "WARNING"
+        level_str = self.settings_service.set_development_mode_log_levels(dev_on)
 
         # コンボボックスの表示を更新
         for combo in (self.view.ui_log_level_combo, self.view.log_level_combo):
             idx = combo.findText(level_str)
             if idx >= 0:
                 combo.setCurrentIndex(idx)
-
-        # 設定値に反映
-        settings.set("ui.general.log_level", level_str)
-        settings.set("logging.level", level_str)
 
         # ロガーに即座に適用
         level = getattr(logging, level_str, logging.WARNING)
@@ -155,20 +151,17 @@ class SettingsPresenter:
     def save_all_settings(self):
         """すべての設定を保存"""
         try:
-            # UI設定
-            settings.set("ui.general.development_mode", self.view.development_mode_check.isChecked())
-            settings.set("ui.general.log_level", self.view.ui_log_level_combo.currentText())
-
-            # 言語設定
+            state = {
+                "development_mode": self.view.development_mode_check.isChecked(),
+                "ui_log_level": self.view.ui_log_level_combo.currentText(),
+                "logging_enabled": self.view.logging_enabled_check.isChecked(),
+                "logging_level": self.view.log_level_combo.currentText(),
+                "log_file_path": self.view.log_file_path_edit.text(),
+            }
             if hasattr(self.view, "language_combo"):
-                settings.set("ui.general.language", self.view.language_combo.currentData())
+                state["language"] = self.view.language_combo.currentData()
 
-            # ログ設定
-            settings.set("logging.enabled", self.view.logging_enabled_check.isChecked())
-            settings.set("logging.level", self.view.log_level_combo.currentText())
-            settings.set("logging.log_file_path", self.view.log_file_path_edit.text())
-
-            settings.save()
+            self.settings_service.save_settings_tab_state(state)
             self._refresh_development_mode_visibility()
             logger.info("設定を保存しました")
             self.app_state.emit_status("Settings saved")
@@ -190,7 +183,7 @@ class SettingsPresenter:
         if reply == QMessageBox.Yes:
             # JSON のデフォルト値で optionVar を上書きしてから UI に反映する。
             # （以前は load_settings() のみで、実際にはリセットされていなかった）
-            settings.reset()
+            self.settings_service.reset()
             self.load_settings()
             self._refresh_development_mode_visibility()
             self.app_state.emit_status("Settings reset to defaults")
@@ -206,18 +199,7 @@ class SettingsPresenter:
 
         if file_path:
             try:
-                # 現在の設定を収集
-                # settings.dataにアクセスして全設定を取得
-                all_settings = get_settings().data
-                export_data = {
-                    "import": all_settings.get("import", {}),
-                    "export": all_settings.get("export", {}),
-                    "logging": all_settings.get("logging", {}),
-                    "ui": all_settings.get("ui", {}),
-                }
-
-                with open(file_path, "w", encoding="utf-8") as f:
-                    json.dump(export_data, f, ensure_ascii=False, indent=2)
+                self.settings_service.write_settings_json(file_path)
 
                 logger.info(f"設定をエクスポートしました: {file_path}")
                 self.app_state.emit_status("Settings exported")
@@ -232,14 +214,7 @@ class SettingsPresenter:
 
         if file_path:
             try:
-                with open(file_path, "r", encoding="utf-8") as f:
-                    import_data = json.load(f)
-
-                # 設定を適用
-                for category in ["import", "export", "logging", "ui"]:
-                    if category in import_data:
-                        for key, value in import_data[category].items():
-                            settings.set(f"{category}.{key}", value)
+                self.settings_service.import_settings_json(file_path)
 
                 # UIを更新
                 self.load_settings()
@@ -273,7 +248,7 @@ class SettingsPresenter:
         selected_language = self.view.language_combo.currentData()
 
         # 設定に保存（即座に永続化）
-        settings.set("ui.general.language", selected_language)
+        self.settings_service.set("ui.general.language", selected_language)
 
         # UITranslatorに言語を設定
         from ...ui.translations import UITranslator

--- a/tests/unit/test_application_state.py
+++ b/tests/unit/test_application_state.py
@@ -1,13 +1,130 @@
 import unittest
 from unittest.mock import Mock
 
-from maya import cmds
+try:
+    from maya import cmds
+    from tests.common.maya_test_base import MayaTestBase
+
+    MAYA_AVAILABLE = True
+except ImportError:
+    cmds = None
+    MayaTestBase = unittest.TestCase
+    MAYA_AVAILABLE = False
 
 from mmd_tools.core.constants import ATTR_MMD_MODEL_NAME_EN, ATTR_MMD_MODEL_NAME
-from tests.common.maya_test_base import MayaTestBase
 from mmd_tools.ui.application_state import ApplicationState
 
 
+class _FakeSceneModelService:
+    def __init__(self):
+        self.models = []
+        self.existing = set()
+        self.selection_model = None
+        self.info = {}
+        self.raise_on_list = False
+
+    def object_exists(self, node):
+        return node in self.existing
+
+    def list_mmd_models(self):
+        if self.raise_on_list:
+            raise RuntimeError("list failed")
+        return list(self.models)
+
+    def resolve_model_from_selection(self, available_models):
+        if self.selection_model in available_models:
+            return self.selection_model
+        return None
+
+    def get_model_info(self, model_root):
+        return self.info.get(model_root, {"root": model_root})
+
+
+class TestApplicationStateWithInjectedService(unittest.TestCase):
+    def test_constructor_accepts_scene_model_service(self):
+        service = _FakeSceneModelService()
+        app_state = ApplicationState(scene_model_service=service)
+
+        self.assertIs(app_state._scene_model_service, service)
+        self.assertIsNone(app_state.current_model_root)
+        self.assertEqual(app_state.available_models, [])
+
+    def test_invalid_current_model_emits_empty_string(self):
+        service = _FakeSceneModelService()
+        app_state = ApplicationState(scene_model_service=service)
+        signal_catcher = Mock()
+        app_state.current_model_changed.connect(signal_catcher)
+
+        app_state.current_model_root = "missing_root"
+
+        self.assertIsNone(app_state.current_model_root)
+        signal_catcher.assert_called_once_with("")
+
+    def test_refresh_model_list_prefers_selection_before_first_model(self):
+        service = _FakeSceneModelService()
+        service.models = ["a_root", "b_root"]
+        service.existing = {"a_root", "b_root"}
+        service.selection_model = "b_root"
+        app_state = ApplicationState(scene_model_service=service)
+
+        app_state.refresh_model_list()
+
+        self.assertEqual(app_state.available_models, ["a_root", "b_root"])
+        self.assertEqual(app_state.current_model_root, "b_root")
+
+    def test_refresh_model_list_auto_selects_first_without_selection(self):
+        service = _FakeSceneModelService()
+        service.models = ["a_root", "b_root"]
+        service.existing = {"a_root", "b_root"}
+        app_state = ApplicationState(scene_model_service=service)
+
+        app_state.refresh_model_list()
+
+        self.assertEqual(app_state.current_model_root, "a_root")
+
+    def test_refresh_model_list_clears_current_missing_from_model_list(self):
+        service = _FakeSceneModelService()
+        service.models = ["old_root"]
+        service.existing = {"old_root"}
+        app_state = ApplicationState(scene_model_service=service)
+        app_state.current_model_root = "old_root"
+        service.models = []
+        signal_catcher = Mock()
+        app_state.current_model_changed.connect(signal_catcher)
+
+        app_state.refresh_model_list()
+
+        self.assertIsNone(app_state.current_model_root)
+        signal_catcher.assert_called_with("")
+
+    def test_refresh_model_list_emits_empty_list_on_exception(self):
+        service = _FakeSceneModelService()
+        service.models = ["old_root"]
+        service.existing = {"old_root"}
+        app_state = ApplicationState(scene_model_service=service)
+        app_state.refresh_model_list()
+        service.raise_on_list = True
+        signal_catcher = Mock()
+        app_state.model_list_updated.connect(signal_catcher)
+
+        app_state.refresh_model_list()
+
+        self.assertEqual(app_state.available_models, [])
+        signal_catcher.assert_called_with([])
+
+    def test_get_model_info_uses_service_and_cache(self):
+        service = _FakeSceneModelService()
+        service.existing = {"model_root"}
+        service.info = {"model_root": {"root": "model_root", "vertex_count": 10}}
+        app_state = ApplicationState(scene_model_service=service)
+
+        info = app_state.get_model_info("model_root")
+
+        self.assertEqual(info["vertex_count"], 10)
+        self.assertIs(app_state.get_model_info("model_root"), info)
+
+
+@unittest.skipUnless(MAYA_AVAILABLE, "Maya is not available")
 class TestApplicationState(MayaTestBase):
     """ApplicationStateの単体テスト"""
 

--- a/tests/unit/test_export_model_action.py
+++ b/tests/unit/test_export_model_action.py
@@ -1,0 +1,41 @@
+"""ExportModelActionのMaya非依存の未実装契約を検証するテスト。"""
+
+import unittest
+
+from tests.common.maya_stub import install_headless_ui_stubs
+
+install_headless_ui_stubs()
+
+from mmd_tools.actions.export_model_action import (  # noqa: E402
+    ExportModelAction,
+    ExportModelRequest,
+)
+
+
+class TestExportModelAction(unittest.TestCase):
+    """PMX/PMD model export action の最小依存境界を検証する。"""
+
+    def test_execute_reports_not_implemented_without_exporter(self):
+        options = {"file_path": "out.pmx", "export_format": "pmx", "apply_scale": True}
+        action = ExportModelAction()
+
+        result = action.execute(ExportModelRequest(file_path="out.pmx", options=options))
+
+        self.assertFalse(result.succeeded)
+        self.assertIsNone(result.exported_path)
+        self.assertIsNone(result.error)
+        self.assertEqual(
+            result.status_message,
+            "PMX export is not implemented yet (scene data collection is unsupported)",
+        )
+
+    def test_request_preserves_options_for_future_exporter_boundary(self):
+        options = {"file_path": "out.pmx", "export_format": "pmx", "apply_scale": False}
+
+        request = ExportModelRequest(file_path="out.pmx", options=options)
+
+        self.assertIs(request.options, options)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_import_export_presenter.py
+++ b/tests/unit/test_import_export_presenter.py
@@ -17,6 +17,7 @@ install_headless_ui_stubs()
 
 from mmd_tools.core.settings import settings  # noqa: E402
 from mmd_tools.actions.import_model_action import ImportModelResult  # noqa: E402
+from mmd_tools.actions.import_vmd_action import ImportVmdResult  # noqa: E402
 from mmd_tools.ui.presenters.import_export_presenter import (  # noqa: E402
     ImportExportPresenter,
 )
@@ -117,6 +118,21 @@ class _FailingImportModelAction:
         raise AssertionError("model action must not be used")
 
 
+class _RecordingImportVmdAction:
+    def __init__(self, result):
+        self.result = result
+        self.requests = []
+
+    def execute(self, request):
+        self.requests.append(request)
+        return self.result
+
+
+class _FailingImportVmdAction:
+    def execute(self, _request):
+        raise AssertionError("vmd action must not be used")
+
+
 class TestImportExportPresenter(unittest.TestCase):
     """ImportExportPresenterのimport options構築を検証する。"""
 
@@ -171,15 +187,13 @@ class TestImportExportPresenter(unittest.TestCase):
         view.import_path_edit = _FakeLineEdit("motion.vmd")
         app_state = _FakeAppState()
         app_state.current_model_root = "model_root"
-        presenter = ImportExportPresenter(view, app_state)
+        action = _RecordingImportVmdAction(ImportVmdResult(root_node=True, succeeded=True))
+        presenter = ImportExportPresenter(view, app_state, import_vmd_action=action)
 
-        with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
-            return_value=True,
-        ) as mock_import:
-            presenter.import_file()
+        presenter.import_file()
 
-        options = mock_import.call_args.kwargs["options"]
+        self.assertEqual(len(action.requests), 1)
+        options = action.requests[0].options
         self.assertEqual(options["target_model"], "model_root")
 
     def test_import_file_passes_profile_and_shows_texture_issue_dialog(self):
@@ -238,7 +252,12 @@ class TestImportExportPresenter(unittest.TestCase):
         view = _RecordingView()
         app_state = _FakeAppState()
         action = _RecordingImportModelAction(ImportModelResult(root_node="model_root", succeeded=True))
-        presenter = ImportExportPresenter(view, app_state, import_model_action=action)
+        presenter = ImportExportPresenter(
+            view,
+            app_state,
+            import_model_action=action,
+            import_vmd_action=_FailingImportVmdAction(),
+        )
 
         presenter.import_file()
 
@@ -256,15 +275,31 @@ class TestImportExportPresenter(unittest.TestCase):
         view = _FakeView()
         view.import_path_edit = _FakeLineEdit("motion.vmd")
         app_state = _FakeAppState()
-        presenter = ImportExportPresenter(view, app_state, import_model_action=_FailingImportModelAction())
+        action = _RecordingImportVmdAction(ImportVmdResult(root_node=True, succeeded=True))
+        presenter = ImportExportPresenter(
+            view,
+            app_state,
+            import_model_action=_FailingImportModelAction(),
+            import_vmd_action=action,
+        )
 
-        with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
-            return_value=True,
-        ) as mock_import:
-            presenter.import_file()
+        presenter.import_file()
 
-        mock_import.assert_called_once()
+        self.assertEqual(len(action.requests), 1)
+        self.assertEqual(action.requests[0].file_path, "motion.vmd")
+
+    def test_import_file_vmd_branch_passes_create_new_scene_to_action(self):
+        view = _FakeView()
+        view.import_path_edit = _FakeLineEdit("motion.vmd")
+        view.new_file_check = _FakeCheckBox(True)
+        app_state = _FakeAppState()
+        action = _RecordingImportVmdAction(ImportVmdResult(root_node=True, succeeded=True))
+        presenter = ImportExportPresenter(view, app_state, import_vmd_action=action)
+
+        presenter.import_file()
+
+        self.assertEqual(len(action.requests), 1)
+        self.assertTrue(action.requests[0].create_new_scene)
 
     def test_import_vmd_auto_detect_uses_current_model_root(self):
         view = _FakeView()
@@ -400,7 +435,7 @@ class TestVmdImportOptions(unittest.TestCase):
         presenter = ImportExportPresenter(view, app_state)
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_vmd_action.import_mmd_file",
             return_value=True,
         ) as mock_import:
             presenter.import_file()
@@ -604,7 +639,7 @@ class TestDevModeBehaviorGating(unittest.TestCase):
         app_state = _FakeAppState()
         presenter = ImportExportPresenter(view, app_state)
         mock_target = (
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file"
+            "mmd_tools.actions.import_vmd_action.import_mmd_file"
             if path.lower().endswith(".vmd")
             else "mmd_tools.actions.import_model_action.import_mmd_file"
         )

--- a/tests/unit/test_import_export_presenter.py
+++ b/tests/unit/test_import_export_presenter.py
@@ -16,6 +16,7 @@ from tests.common.maya_stub import install_headless_ui_stubs
 install_headless_ui_stubs()
 
 from mmd_tools.core.settings import settings  # noqa: E402
+from mmd_tools.actions.export_model_action import ExportModelResult  # noqa: E402
 from mmd_tools.actions.import_model_action import ImportModelResult  # noqa: E402
 from mmd_tools.actions.import_vmd_action import ImportVmdResult  # noqa: E402
 from mmd_tools.ui.presenters.import_export_presenter import (  # noqa: E402
@@ -131,6 +132,21 @@ class _RecordingImportVmdAction:
 class _FailingImportVmdAction:
     def execute(self, _request):
         raise AssertionError("vmd action must not be used")
+
+
+class _RecordingExportModelAction:
+    def __init__(self, result):
+        self.result = result
+        self.requests = []
+
+    def execute(self, request):
+        self.requests.append(request)
+        return self.result
+
+
+class _FailingExportModelAction:
+    def execute(self, _request):
+        raise AssertionError("export action must not be used")
 
 
 class TestImportExportPresenter(unittest.TestCase):
@@ -547,7 +563,7 @@ class TestExportFile(unittest.TestCase):
         view = _FakeView()
         view.export_path_edit = _FakeLineEdit("")
         app_state = _FakeAppState()
-        presenter = ImportExportPresenter(view, app_state)
+        presenter = ImportExportPresenter(view, app_state, export_model_action=_FailingExportModelAction())
         presenter.export_file()
         self.assertIn("Please enter a file path", app_state.statuses)
 
@@ -555,8 +571,15 @@ class TestExportFile(unittest.TestCase):
         view = _FakeView()
         view.export_path_edit = _FakeLineEdit("out.pmx")
         app_state = _FakeAppState()
-        presenter = ImportExportPresenter(view, app_state)
+        action = _RecordingExportModelAction(
+            ExportModelResult(
+                status_message="PMX export is not implemented yet (scene data collection is unsupported)"
+            )
+        )
+        presenter = ImportExportPresenter(view, app_state, export_model_action=action)
         presenter.export_file()
+        self.assertEqual(len(action.requests), 1)
+        self.assertEqual(action.requests[0].file_path, "out.pmx")
         self.assertTrue(
             any("not implemented" in s.lower() for s in app_state.statuses)
         )
@@ -604,6 +627,30 @@ class TestExportFile(unittest.TestCase):
         self.assertTrue(
             any("not implemented" in s.lower() for s in app_state.statuses)
         )
+
+    def test_export_file_passes_built_options_to_injected_action(self):
+        settings.set("export.general.export_format", "pmx")
+        settings.set("export.general.apply_scale", False)
+        view = _FakeView()
+        view.export_path_edit = _FakeLineEdit("  out.pmx  ")
+        app_state = _FakeAppState()
+        action = _RecordingExportModelAction(ExportModelResult(status_message="not implemented"))
+        presenter = ImportExportPresenter(view, app_state, export_model_action=action)
+
+        presenter.export_file()
+
+        self.assertEqual(len(action.requests), 1)
+        request = action.requests[0]
+        self.assertEqual(request.file_path, "out.pmx")
+        self.assertEqual(
+            request.options,
+            {
+                "file_path": "out.pmx",
+                "export_format": "pmx",
+                "apply_scale": False,
+            },
+        )
+        self.assertIn("not implemented", app_state.statuses)
 
 
 class TestDevModeBehaviorGating(unittest.TestCase):

--- a/tests/unit/test_import_export_presenter.py
+++ b/tests/unit/test_import_export_presenter.py
@@ -16,6 +16,7 @@ from tests.common.maya_stub import install_headless_ui_stubs
 install_headless_ui_stubs()
 
 from mmd_tools.core.settings import settings  # noqa: E402
+from mmd_tools.actions.import_model_action import ImportModelResult  # noqa: E402
 from mmd_tools.ui.presenters.import_export_presenter import (  # noqa: E402
     ImportExportPresenter,
 )
@@ -101,6 +102,21 @@ class _FakeAppState:
         pass
 
 
+class _RecordingImportModelAction:
+    def __init__(self, result):
+        self.result = result
+        self.requests = []
+
+    def execute(self, request):
+        self.requests.append(request)
+        return self.result
+
+
+class _FailingImportModelAction:
+    def execute(self, _request):
+        raise AssertionError("model action must not be used")
+
+
 class TestImportExportPresenter(unittest.TestCase):
     """ImportExportPresenterのimport options構築を検証する。"""
 
@@ -123,7 +139,7 @@ class TestImportExportPresenter(unittest.TestCase):
         presenter = ImportExportPresenter(view, app_state)
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
             return_value="model_root",
         ) as mock_import:
             presenter.import_file()
@@ -141,7 +157,7 @@ class TestImportExportPresenter(unittest.TestCase):
         presenter = ImportExportPresenter(view, app_state)
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
             return_value="model_root",
         ) as mock_import:
             presenter.import_file()
@@ -178,7 +194,7 @@ class TestImportExportPresenter(unittest.TestCase):
             return "model_root"
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
             side_effect=fake_import,
         ) as mock_import, patch(
             "mmd_tools.ui.texture_issue_dialog.TextureIssueDialog",
@@ -201,12 +217,54 @@ class TestImportExportPresenter(unittest.TestCase):
             return "model_root"
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
             side_effect=fake_import,
         ), patch("mmd_tools.ui.texture_issue_dialog.TextureIssueDialog") as mock_dialog:
             presenter.import_file()
 
         mock_dialog.assert_not_called()
+
+    def test_import_file_model_branch_uses_injected_action_and_updates_ui_state(self):
+        recorded_refreshes = []
+        recorded_history = []
+
+        class _RecordingView(_FakeView):
+            def refresh_model_list(self):
+                recorded_refreshes.append("refresh")
+
+            def add_import_path_to_history(self, path):
+                recorded_history.append(path)
+
+        view = _RecordingView()
+        app_state = _FakeAppState()
+        action = _RecordingImportModelAction(ImportModelResult(root_node="model_root", succeeded=True))
+        presenter = ImportExportPresenter(view, app_state, import_model_action=action)
+
+        presenter.import_file()
+
+        self.assertEqual(len(action.requests), 1)
+        self.assertEqual(action.requests[0].file_path, "model.pmx")
+        self.assertIn("profile", action.requests[0].options)
+        self.assertFalse(action.requests[0].create_new_scene)
+        self.assertEqual(app_state.current_model_root, "model_root")
+        self.assertIn("Import complete: model_root", app_state.statuses)
+        self.assertIn(100, app_state.progress)
+        self.assertEqual(recorded_refreshes, ["refresh"])
+        self.assertEqual(recorded_history, ["model.pmx"])
+
+    def test_import_file_vmd_branch_does_not_use_model_action(self):
+        view = _FakeView()
+        view.import_path_edit = _FakeLineEdit("motion.vmd")
+        app_state = _FakeAppState()
+        presenter = ImportExportPresenter(view, app_state, import_model_action=_FailingImportModelAction())
+
+        with patch(
+            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            return_value=True,
+        ) as mock_import:
+            presenter.import_file()
+
+        mock_import.assert_called_once()
 
     def test_import_vmd_auto_detect_uses_current_model_root(self):
         view = _FakeView()
@@ -250,7 +308,7 @@ class TestImportFileGuards(unittest.TestCase):
         presenter = ImportExportPresenter(view, app_state)
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
         ) as mock_import:
             presenter.import_file()
 
@@ -263,7 +321,7 @@ class TestImportFileGuards(unittest.TestCase):
         presenter = ImportExportPresenter(view, app_state)
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
             return_value="returned_root",
         ):
             presenter.import_file()
@@ -278,7 +336,7 @@ class TestImportFileGuards(unittest.TestCase):
         presenter = ImportExportPresenter(view, app_state)
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
             return_value=None,
         ):
             presenter.import_file()
@@ -293,7 +351,7 @@ class TestImportFileGuards(unittest.TestCase):
         presenter = ImportExportPresenter(view, app_state)
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
             side_effect=RuntimeError("boom"),
         ):
             # 例外は presenter 内で捕捉される
@@ -319,7 +377,7 @@ class TestImportFileGuards(unittest.TestCase):
         cmds.file.reset_mock()
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
             return_value="root",
         ):
             presenter.import_file()
@@ -367,7 +425,7 @@ class TestVmdImportOptions(unittest.TestCase):
         presenter = ImportExportPresenter(view, app_state)
 
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            "mmd_tools.actions.import_model_action.import_mmd_file",
             return_value="root",
         ) as mock_import:
             presenter.import_file()
@@ -545,8 +603,13 @@ class TestDevModeBehaviorGating(unittest.TestCase):
         view.import_path_edit = _FakeLineEdit(path)
         app_state = _FakeAppState()
         presenter = ImportExportPresenter(view, app_state)
+        mock_target = (
+            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file"
+            if path.lower().endswith(".vmd")
+            else "mmd_tools.actions.import_model_action.import_mmd_file"
+        )
         with patch(
-            "mmd_tools.ui.presenters.import_export_presenter.import_mmd_file",
+            mock_target,
             return_value="root",
         ) as mock_import:
             presenter.import_file()

--- a/tests/unit/test_import_model_action.py
+++ b/tests/unit/test_import_model_action.py
@@ -1,0 +1,104 @@
+"""ImportModelActionのMaya非依存の実行契約を検証するテスト。"""
+
+import unittest
+
+from tests.common.maya_stub import install_headless_ui_stubs
+
+install_headless_ui_stubs()
+
+from mmd_tools.actions.import_model_action import (  # noqa: E402
+    ImportModelAction,
+    ImportModelRequest,
+)
+
+
+class TestImportModelAction(unittest.TestCase):
+    """PMX/PMD model import action の依存境界を検証する。"""
+
+    def test_execute_calls_importer_with_file_path_and_options(self):
+        calls = []
+        options = {"scale": 1.0}
+
+        def importer(file_path, options=None):
+            calls.append((file_path, options))
+            return "root"
+
+        action = ImportModelAction(importer=importer, new_scene=lambda: None)
+        result = action.execute(ImportModelRequest("model.pmx", options))
+
+        self.assertTrue(result.succeeded)
+        self.assertEqual(result.root_node, "root")
+        self.assertIsNone(result.error)
+        self.assertEqual(calls, [("model.pmx", options)])
+        self.assertIs(calls[0][1], options)
+
+    def test_execute_calls_new_scene_before_import_when_requested(self):
+        calls = []
+
+        def new_scene():
+            calls.append("new_scene")
+
+        def importer(_file_path, options=None):
+            calls.append("importer")
+            return "root"
+
+        action = ImportModelAction(importer=importer, new_scene=new_scene)
+        result = action.execute(ImportModelRequest("model.pmx", {}, create_new_scene=True))
+
+        self.assertTrue(result.succeeded)
+        self.assertEqual(calls, ["new_scene", "importer"])
+
+    def test_execute_does_not_call_new_scene_when_not_requested(self):
+        calls = []
+
+        def new_scene():
+            calls.append("new_scene")
+
+        def importer(_file_path, options=None):
+            calls.append("importer")
+            return "root"
+
+        action = ImportModelAction(importer=importer, new_scene=new_scene)
+        result = action.execute(ImportModelRequest("model.pmx", {}))
+
+        self.assertTrue(result.succeeded)
+        self.assertEqual(calls, ["importer"])
+
+    def test_execute_returns_failure_when_importer_returns_none(self):
+        action = ImportModelAction(importer=lambda _path, options=None: None, new_scene=lambda: None)
+
+        result = action.execute(ImportModelRequest("model.pmx", {}))
+
+        self.assertFalse(result.succeeded)
+        self.assertIsNone(result.root_node)
+        self.assertIsNone(result.error)
+
+    def test_execute_converts_importer_exception_to_result_error(self):
+        error = RuntimeError("boom")
+
+        def importer(_file_path, options=None):
+            raise error
+
+        action = ImportModelAction(importer=importer, new_scene=lambda: None)
+        result = action.execute(ImportModelRequest("model.pmx", {}))
+
+        self.assertFalse(result.succeeded)
+        self.assertIsNone(result.root_node)
+        self.assertIs(result.error, error)
+
+    def test_execute_converts_new_scene_exception_to_result_error(self):
+        error = RuntimeError("new scene failed")
+
+        def new_scene():
+            raise error
+
+        action = ImportModelAction(importer=lambda _path, options=None: "root", new_scene=new_scene)
+        result = action.execute(ImportModelRequest("model.pmx", {}, create_new_scene=True))
+
+        self.assertFalse(result.succeeded)
+        self.assertIsNone(result.root_node)
+        self.assertIs(result.error, error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_import_vmd_action.py
+++ b/tests/unit/test_import_vmd_action.py
@@ -1,0 +1,104 @@
+"""ImportVmdActionのMaya非依存の実行契約を検証するテスト。"""
+
+import unittest
+
+from tests.common.maya_stub import install_headless_ui_stubs
+
+install_headless_ui_stubs()
+
+from mmd_tools.actions.import_vmd_action import (  # noqa: E402
+    ImportVmdAction,
+    ImportVmdRequest,
+)
+
+
+class TestImportVmdAction(unittest.TestCase):
+    """VMD import action の依存境界を検証する。"""
+
+    def test_execute_calls_importer_with_file_path_and_options(self):
+        calls = []
+        options = {"target_model": "model_root"}
+
+        def importer(file_path, options=None):
+            calls.append((file_path, options))
+            return "motion_root"
+
+        action = ImportVmdAction(importer=importer, new_scene=lambda: None)
+        result = action.execute(ImportVmdRequest("motion.vmd", options))
+
+        self.assertTrue(result.succeeded)
+        self.assertEqual(result.root_node, "motion_root")
+        self.assertIsNone(result.error)
+        self.assertEqual(calls, [("motion.vmd", options)])
+        self.assertIs(calls[0][1], options)
+
+    def test_execute_calls_new_scene_before_import_when_requested(self):
+        calls = []
+
+        def new_scene():
+            calls.append("new_scene")
+
+        def importer(_file_path, options=None):
+            calls.append("importer")
+            return "motion_root"
+
+        action = ImportVmdAction(importer=importer, new_scene=new_scene)
+        result = action.execute(ImportVmdRequest("motion.vmd", {}, create_new_scene=True))
+
+        self.assertTrue(result.succeeded)
+        self.assertEqual(calls, ["new_scene", "importer"])
+
+    def test_execute_does_not_call_new_scene_when_not_requested(self):
+        calls = []
+
+        def new_scene():
+            calls.append("new_scene")
+
+        def importer(_file_path, options=None):
+            calls.append("importer")
+            return "motion_root"
+
+        action = ImportVmdAction(importer=importer, new_scene=new_scene)
+        result = action.execute(ImportVmdRequest("motion.vmd", {}))
+
+        self.assertTrue(result.succeeded)
+        self.assertEqual(calls, ["importer"])
+
+    def test_execute_returns_failure_when_importer_returns_none(self):
+        action = ImportVmdAction(importer=lambda _path, options=None: None, new_scene=lambda: None)
+
+        result = action.execute(ImportVmdRequest("motion.vmd", {}))
+
+        self.assertFalse(result.succeeded)
+        self.assertIsNone(result.root_node)
+        self.assertIsNone(result.error)
+
+    def test_execute_converts_importer_exception_to_result_error(self):
+        error = RuntimeError("boom")
+
+        def importer(_file_path, options=None):
+            raise error
+
+        action = ImportVmdAction(importer=importer, new_scene=lambda: None)
+        result = action.execute(ImportVmdRequest("motion.vmd", {}))
+
+        self.assertFalse(result.succeeded)
+        self.assertIsNone(result.root_node)
+        self.assertIs(result.error, error)
+
+    def test_execute_converts_new_scene_exception_to_result_error(self):
+        error = RuntimeError("new scene failed")
+
+        def new_scene():
+            raise error
+
+        action = ImportVmdAction(importer=lambda _path, options=None: "motion_root", new_scene=new_scene)
+        result = action.execute(ImportVmdRequest("motion.vmd", {}, create_new_scene=True))
+
+        self.assertFalse(result.succeeded)
+        self.assertIsNone(result.root_node)
+        self.assertIs(result.error, error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_scene_model_service.py
+++ b/tests/unit/test_scene_model_service.py
@@ -1,0 +1,154 @@
+import unittest
+
+from mmd_tools.core.constants import ATTR_MMD_MODEL_NAME, ATTR_MMD_MODEL_NAME_EN
+from mmd_tools.services.scene_model_service import SceneModelService
+
+
+class _FakeCmds:
+    def __init__(self):
+        self.existing = set()
+        self.transforms = []
+        self.attrs = {}
+        self.parents = {}
+        self.selection = []
+        self.meshes = {}
+        self.joints = {}
+        self.vertices = {}
+        self.connections = {}
+        self.materials_for_connections = {}
+        self.history = {}
+        self.blend_targets = {}
+        self.selected = None
+
+    def objExists(self, node):
+        return node in self.existing
+
+    def ls(self, *args, **kwargs):
+        if kwargs.get("selection"):
+            return list(self.selection)
+        if kwargs.get("type") == "transform":
+            return list(self.transforms)
+        if kwargs.get("materials"):
+            materials = []
+            for item in args[0] or []:
+                materials.extend(self.materials_for_connections.get(item, []))
+            return materials
+        if kwargs.get("type") == "blendShape":
+            return list(args[0] or [])
+        return list(args[0] or [])
+
+    def attributeQuery(self, attr, node, exists):
+        return exists and attr in self.attrs.get(node, {})
+
+    def getAttr(self, attr_path):
+        node, attr = attr_path.rsplit(".", 1)
+        return self.attrs.get(node, {}).get(attr)
+
+    def listRelatives(self, node, **kwargs):
+        if kwargs.get("parent"):
+            parent = self.parents.get(node)
+            return [parent] if parent else []
+        if kwargs.get("type") == "mesh":
+            return list(self.meshes.get(node, []))
+        if kwargs.get("type") == "joint":
+            return list(self.joints.get(node, []))
+        return []
+
+    def polyEvaluate(self, shape, vertex):
+        return self.vertices.get(shape, 0) if vertex else 0
+
+    def listConnections(self, node, **kwargs):
+        if isinstance(node, list):
+            result = []
+            for item in node:
+                result.extend(self.connections.get(item, []))
+            return result
+        return list(self.connections.get(node, []))
+
+    def listHistory(self, shapes):
+        result = []
+        for shape in shapes:
+            result.extend(self.history.get(shape, []))
+        return result
+
+    def blendShape(self, node, **kwargs):
+        if kwargs.get("query") and kwargs.get("target"):
+            return list(self.blend_targets.get(node, []))
+        return []
+
+    def select(self, nodes, replace=True):
+        self.selected = (nodes, replace)
+
+
+class TestSceneModelService(unittest.TestCase):
+    def test_list_mmd_models_returns_sorted_mmd_roots_only(self):
+        cmds = _FakeCmds()
+        cmds.transforms = ["b_root", "not_mmd_root", "ns:a_root", "b_root"]
+        cmds.attrs = {
+            "b_root": {ATTR_MMD_MODEL_NAME: "B"},
+            "ns:a_root": {ATTR_MMD_MODEL_NAME_EN: "A"},
+        }
+        service = SceneModelService(cmds_module=cmds)
+
+        self.assertEqual(service.list_mmd_models(), ["b_root", "ns:a_root"])
+
+    def test_resolve_model_from_selection_prefers_available_full_path_then_short_name(self):
+        cmds = _FakeCmds()
+        cmds.selection = ["|grp|child"]
+        cmds.parents = {"|grp|child": "|grp|model_root"}
+        cmds.attrs = {"|grp|model_root": {ATTR_MMD_MODEL_NAME: "Model"}}
+        service = SceneModelService(cmds_module=cmds)
+
+        self.assertEqual(service.resolve_model_from_selection(["|grp|model_root"]), "|grp|model_root")
+        self.assertEqual(service.resolve_model_from_selection(["model_root"]), "model_root")
+
+    def test_get_model_display_name_uses_japanese_then_english_then_node_name(self):
+        cmds = _FakeCmds()
+        cmds.attrs = {
+            "jp_root": {ATTR_MMD_MODEL_NAME: "日本語名", ATTR_MMD_MODEL_NAME_EN: "English"},
+            "en_root": {ATTR_MMD_MODEL_NAME_EN: "English"},
+        }
+        service = SceneModelService(cmds_module=cmds)
+
+        self.assertEqual(service.get_model_display_name("jp_root"), "日本語名")
+        self.assertEqual(service.get_model_display_name("en_root"), "English")
+        self.assertEqual(service.get_model_display_name("plain_root"), "plain")
+
+    def test_get_model_info_collects_summary_counts(self):
+        cmds = _FakeCmds()
+        cmds.existing = {"ns:model_root"}
+        cmds.attrs = {"ns:model_root": {ATTR_MMD_MODEL_NAME: "表示名", ATTR_MMD_MODEL_NAME_EN: "Name"}}
+        cmds.meshes = {"ns:model_root": ["meshShape1", "meshShape2"]}
+        cmds.vertices = {"meshShape1": 8, "meshShape2": 4}
+        cmds.connections = {
+            "meshShape1": ["sg1"],
+            "meshShape2": ["sg1", "sg2"],
+            "sg1": ["mat1"],
+            "sg2": ["mat2"],
+        }
+        cmds.materials_for_connections = {"mat1": ["mat1"], "mat2": ["mat2"]}
+        cmds.joints = {"ns:model_root": ["j1", "j2"]}
+        cmds.history = {"meshShape1": ["bs1"], "meshShape2": ["bs2"]}
+        cmds.blend_targets = {"bs1": ["smile"], "bs2": ["blink", "angry"]}
+        service = SceneModelService(cmds_module=cmds)
+
+        info = service.get_model_info("ns:model_root")
+
+        self.assertEqual(info["namespace"], "ns")
+        self.assertEqual(info["display_name"], "表示名")
+        self.assertEqual(info["vertex_count"], 12)
+        self.assertEqual(info["material_count"], 2)
+        self.assertEqual(info["bone_count"], 2)
+        self.assertEqual(info["morph_count"], 3)
+
+    def test_get_attr_safe_returns_default_for_missing_or_none(self):
+        cmds = _FakeCmds()
+        cmds.attrs = {"node": {"present": None}}
+        service = SceneModelService(cmds_module=cmds)
+
+        self.assertEqual(service.get_attr_safe("node", "present", "fallback"), "fallback")
+        self.assertEqual(service.get_attr_safe("node", "missing", "fallback"), "fallback")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -1,0 +1,245 @@
+"""SettingsService の設定 I/O と option dict 構築を検証する。"""
+
+import copy
+import os
+import sys
+import unittest
+from unittest.mock import mock_open, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from mmd_tools.services.settings_service import SettingsService  # noqa: E402
+
+
+class _FakeSettingsStore:
+    def __init__(self):
+        self.data = {
+            "import": {
+                "general": {"scale_factor": 2.0, "use_namespace": True},
+                "model": {
+                    "import_models": False,
+                    "create_mmd_shaders": False,
+                    "separate_meshes_by_material": True,
+                    "split_meshes_by_morph_groups": True,
+                    "hide_hidden_geometry": True,
+                    "auto_classify_transparency": True,
+                    "disable_backface_culling": False,
+                    "uv_set_name": "customUV",
+                    "texture_search_path": "/textures",
+                    "show_texture_issue_dialog": False,
+                },
+                "physics": {"import_physics": True},
+                "morph": {"import_morphs": False},
+                "rig": {"add_semi_standard_bones": True, "bake_mode": False},
+                "native": {"use_cpp_fast_load": True, "cpp_fast_load_mesh_only": False},
+                "naming": {"translate_names": False},
+                "animation": {
+                    "animation_start_frame": 12,
+                    "vmd_fps": 60,
+                    "import_animations": False,
+                    "import_morph_animation": False,
+                    "import_camera_animation": False,
+                    "import_light_animation": False,
+                    "resample_curves": True,
+                },
+            },
+            "export": {"general": {"export_format": "pmd", "apply_scale": False}},
+            "logging": {"enabled": False, "level": "ERROR", "log_file_path": "custom.log"},
+            "ui": {"general": {"development_mode": False, "log_level": "ERROR", "language": "en"}},
+            "internal": {"ignored": True},
+        }
+        self.saved = 0
+        self.reset_called = 0
+        self.set_calls = []
+
+    def get(self, key_path, default=None):
+        value = self.data
+        for key in key_path.split("."):
+            try:
+                value = value[key]
+            except (KeyError, TypeError):
+                return default
+        return value
+
+    def set(self, key_path, value):
+        keys = key_path.split(".")
+        target = self.data
+        for key in keys[:-1]:
+            target = target.setdefault(key, {})
+        target[keys[-1]] = value
+        self.set_calls.append((key_path, value))
+        self.save()
+
+    def save(self):
+        self.saved += 1
+
+    def reset(self):
+        self.reset_called += 1
+        self.save()
+
+
+class TestSettingsServiceDelegation(unittest.TestCase):
+    def setUp(self):
+        self.store = _FakeSettingsStore()
+        self.service = SettingsService(self.store)
+
+    def test_get_set_save_reset_delegate_to_store(self):
+        self.assertEqual(self.service.get("ui.general.language"), "en")
+
+        self.service.set("ui.general.language", "ja")
+        self.service.save()
+        self.service.reset()
+
+        self.assertEqual(self.service.get("ui.general.language"), "ja")
+        self.assertIn(("ui.general.language", "ja"), self.store.set_calls)
+        self.assertEqual(self.store.saved, 3)
+        self.assertEqual(self.store.reset_called, 1)
+
+    def test_set_development_mode_log_levels_sets_both_keys(self):
+        level = self.service.set_development_mode_log_levels(True)
+
+        self.assertEqual(level, "INFO")
+        self.assertEqual(self.service.get("ui.general.log_level"), "INFO")
+        self.assertEqual(self.service.get("logging.level"), "INFO")
+
+        level = self.service.set_development_mode_log_levels(False)
+
+        self.assertEqual(level, "WARNING")
+        self.assertEqual(self.service.get("ui.general.log_level"), "WARNING")
+        self.assertEqual(self.service.get("logging.level"), "WARNING")
+
+    def test_load_and_save_settings_tab_state_preserve_keys(self):
+        state = self.service.load_settings_tab_state()
+        self.assertEqual(
+            state,
+            {
+                "development_mode": False,
+                "ui_log_level": "ERROR",
+                "logging_enabled": False,
+                "logging_level": "ERROR",
+                "log_file_path": "custom.log",
+                "language": "en",
+            },
+        )
+
+        self.service.save_settings_tab_state(
+            {
+                "development_mode": True,
+                "ui_log_level": "DEBUG",
+                "logging_enabled": True,
+                "logging_level": "INFO",
+                "log_file_path": "next.log",
+                "language": "ja",
+            }
+        )
+
+        self.assertTrue(self.service.get("ui.general.development_mode"))
+        self.assertEqual(self.service.get("ui.general.log_level"), "DEBUG")
+        self.assertEqual(self.service.get("ui.general.language"), "ja")
+        self.assertTrue(self.service.get("logging.enabled"))
+        self.assertEqual(self.service.get("logging.level"), "INFO")
+        self.assertEqual(self.service.get("logging.log_file_path"), "next.log")
+
+
+class TestSettingsServiceJson(unittest.TestCase):
+    def setUp(self):
+        self.store = _FakeSettingsStore()
+        self.service = SettingsService(self.store)
+
+    def test_export_settings_data_uses_expected_categories_only(self):
+        data = self.service.export_settings_data()
+
+        self.assertEqual(set(data), {"import", "export", "logging", "ui"})
+        self.assertNotIn("internal", data)
+
+    def test_write_and_import_settings_json(self):
+        path = "settings.json"
+        exported_data = copy.deepcopy(self.service.export_settings_data())
+        with patch("builtins.open", mock_open()) as mocked_open:
+            self.service.write_settings_json(path)
+
+        mocked_open.assert_called_with(path, "w", encoding="utf-8")
+
+        self.store.data["logging"]["level"] = "DEBUG"
+        with patch.object(self.service, "read_settings_json", return_value=exported_data):
+            self.service.import_settings_json(path)
+
+        self.assertEqual(self.service.get("logging.level"), "ERROR")
+        self.assertIn(("logging.level", "ERROR"), self.store.set_calls)
+
+
+class TestSettingsServiceImportOptions(unittest.TestCase):
+    def setUp(self):
+        self.store = _FakeSettingsStore()
+        self.service = SettingsService(self.store)
+
+    def test_build_pmx_import_options_applies_normal_mode_overrides(self):
+        options = self.service.build_pmx_import_options(custom_namespace="ns")
+
+        self.assertEqual(options["scale"], 2.0)
+        self.assertTrue(options["use_namespace"])
+        self.assertEqual(options["custom_namespace"], "ns")
+        self.assertTrue(options["import_models"])
+        self.assertFalse(options["import_physics"])
+        self.assertFalse(options["separate_meshes_by_material"])
+        self.assertFalse(options["split_meshes_by_morph_groups"])
+        self.assertFalse(options["hide_hidden_geometry"])
+        self.assertFalse(options["auto_classify_transparency"])
+        self.assertTrue(options["disable_backface_culling"])
+        self.assertEqual(options["uv_set_name"], "map#")
+        self.assertEqual(options["texture_search_path"], "")
+        self.assertFalse(options["add_semi_standard_bones"])
+        self.assertTrue(options["translate_names"])
+        self.assertFalse(options["setup_rig"])
+        self.assertFalse(options["setup_bone_orientation"])
+        self.assertTrue(options["use_cpp_fast_load"])
+        self.assertFalse(options["cpp_fast_load_mesh_only"])
+
+    def test_build_pmx_import_options_preserves_dev_mode_saved_values(self):
+        self.service.set("ui.general.development_mode", True)
+
+        options = self.service.build_pmx_import_options()
+
+        self.assertFalse(options["import_models"])
+        self.assertTrue(options["import_physics"])
+        self.assertTrue(options["separate_meshes_by_material"])
+        self.assertTrue(options["split_meshes_by_morph_groups"])
+        self.assertTrue(options["hide_hidden_geometry"])
+        self.assertTrue(options["auto_classify_transparency"])
+        self.assertFalse(options["disable_backface_culling"])
+        self.assertEqual(options["uv_set_name"], "customUV")
+        self.assertEqual(options["texture_search_path"], "/textures")
+        self.assertTrue(options["add_semi_standard_bones"])
+        self.assertFalse(options["translate_names"])
+        self.assertNotIn("setup_rig", options)
+        self.assertNotIn("setup_bone_orientation", options)
+
+    def test_build_vmd_import_options_forces_resample_curves_in_normal_mode(self):
+        options = self.service.build_vmd_import_options(target_model="model")
+
+        self.assertEqual(options["start_frame"], 12)
+        self.assertEqual(options["vmd_fps"], 60)
+        self.assertFalse(options["import_bone_animation"])
+        self.assertFalse(options["import_morph_animation"])
+        self.assertFalse(options["import_camera_animation"])
+        self.assertFalse(options["import_light_animation"])
+        self.assertFalse(options["resample_curves"])
+        self.assertEqual(options["target_model"], "model")
+
+    def test_build_vmd_import_options_preserves_resample_curves_in_dev_mode(self):
+        self.service.set("ui.general.development_mode", True)
+
+        options = self.service.build_vmd_import_options()
+
+        self.assertTrue(options["resample_curves"])
+        self.assertIsNone(options["target_model"])
+
+    def test_build_export_options_and_texture_dialog_setting(self):
+        options = self.service.build_export_options("out.pmx")
+
+        self.assertEqual(options, {"file_path": "out.pmx", "export_format": "pmd", "apply_scale": False})
+        self.assertFalse(self.service.should_show_texture_issue_dialog())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

#80 Qt アーキテクチャ リファクタ。Maya 実処理・設定 I/O・シーン状態取得を Presenter / ApplicationState から専用レイヤ（Action / Service）へ切り出し、Qt 非依存・依存性注入でヘッドレステスト可能にする。**挙動は保存**（status/progress/履歴/dialog/warning log・signal 契約・public API・各種既定値すべて不変）。

## 変更内容（5 コミット）

| コミット | 内容 |
|---|---|
| `53bdb21` | **ImportModelAction** を `ImportExportPresenter` から抽出（`mmd_tools/actions/`） |
| `6464085` | **ImportVmdAction** を抽出 |
| `99a3f4b` | **ExportModelAction** を抽出（export 未実装の honest な挙動を維持、exporter 非呼び出し） |
| `0bb8908` | **SettingsService** を抽出（`mmd_tools/services/`）。設定 I/O・JSON import/export・オプション辞書構築（PMX/VMD/export + normal/dev override）を集約 |
| `9b13733` | **SceneModelService** を抽出。Maya シーン/モデル状態取得（列挙・選択解決・存在確認・モデル概要）を `ApplicationState` から分離し内部利用 |

### 設計パターン
- 各 Action / Service は Qt 非依存。`importer` / `cmds_module` 等の callable・モジュールを optional 注入してヘッドレステスト可能。
- Presenter / ApplicationState のコンストラクタは後方互換のため optional 引数（`import_model_action=None` / `settings_service=None` / `scene_model_service=None` 等）を受け、None なら内部生成。
- `maya.cmds` / optionVar / global singleton に触れずに純 Python でユニットテストできる。

## 挙動保存（重要）
- import/export の status・progress・履歴追加・texture issue dialog 条件・warning log すべて不変。
- 設定: optionVar prefix/flatten・即保存タイミング・normal/dev override 値・JSON カテゴリ・default fallback 不変。
- シーン状態: `refresh_model_list` の発火条件/モデル順・自動選択（Maya 選択優先→なければ先頭）・存在しない root で `current_model_changed("")` emit・例外時 `model_list_updated([])` emit 不変。
- public API（`current_model_root` / `available_models` / `get_model_info` / `clear_cache`）と signal 契約を維持。

## テスト
- `ci_unit`（純 Python 回帰、mayapy 不要）: **474 tests OK**。
- 新規ユニットテスト: `test_import_model_action` / `test_import_vmd_action` / `test_export_model_action` / `test_settings_service` / `test_scene_model_service`、および presenter / application_state の注入回帰。
- 各 PR で独立 Codex Review を実施、いずれもクリーン（破壊的問題なし）。

## スコープ外（フォローアップ候補）
- `ImportExportTab` の VMD target combo のモデル列挙（View コンストラクタ波及大のため見送り）。
- 骨/材質/モーフ/physics/display-pane の各タブ固有編集ロジックの Service 化。
- `MainWindow` / `ImportExportTab` の `QSettings`（geometry・ファイル履歴等の UI 状態）。
- 段階計画の残フェーズ: **P7 MayaCmdsAdapter**（`maya.cmds` 直叩きを Adapter 層へ隔離）/ **P8 UI テスト軽量化**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CX2y9fmYgPP4D374jywU8e
