### PR TITLE
Add pull request lint CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  push:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Ruff
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install lint tools
+        run: python -m pip install --upgrade pip ruff
+
+      - name: Ruff
+        run: ruff check --no-fix .


### PR DESCRIPTION
## Summary

- Add a normal CI workflow for `pull_request` and `push` on `main` / `develop`.
- Run the same release-gate lint command, `ruff check --no-fix .`, before changes reach the tag-only release workflow.
- Keep the release workflow focused on packaging and publishing tag builds.

## Validation

- `rtk ruff check --no-fix .`
- `git diff --check -- .github/workflows/ci.yml`